### PR TITLE
Fix argument handling in bearer token script

### DIFF
--- a/getBearer.js
+++ b/getBearer.js
@@ -5,10 +5,17 @@ const cliArgs = process.argv.slice(2); // Get command line arguments
 
 const repo = cliArgs[0]; // Docker image repository name from arguments
 
-async function displayBearer(repo) {
-    const tokenResponse = await axios.get(`https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull`);
-    const token = tokenResponse.data.token;
-    console.log(`Bearer ${token}`);
+if (!repo) {
+  console.error('Please provide a repository as argument');
+  process.exit(1);
+}
+
+async function displayBearer(repository) {
+  const tokenResponse = await axios.get(
+    `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repository}:pull`
+  );
+  const token = tokenResponse.data.token;
+  console.log(`Bearer ${token}`);
 }
 
 displayBearer(repo);


### PR DESCRIPTION
## Summary
- validate command line arguments in `getBearer.js`
- exit with an informative message when repo argument is missing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68453f518624832a859bd3f9b21107e3