### PR TITLE
Fix RPM upload Dropzone to accept .rpm and RPM MIME types

### DIFF
--- a/src/app/rpm/upload.tsx
+++ b/src/app/rpm/upload.tsx
@@ -178,7 +178,12 @@ export function UploadPane({ env }: { env: EnvProps }) {
         <div>
             <Alert variant="light" color="yellow" title="注意" radius="lg" my="xl">アップロード先RPMリポジトリは URL/認証方式が実装により異なります。PUT/POST を切り替えて利用してください。</Alert>
             <Stack>
-                <Dropzone accept={['application/x-redhat-package-manager', 'application/octet-stream']} onDrop={(files) => form.setFieldValue('files', [...form.getValues().files, ...files])} onReject={() => setError('rpmファイルのみアップロードできます')} disabled={loading}>
+                <Dropzone
+                    accept={['.rpm', 'application/x-rpm', 'application/x-redhat-package-manager', 'application/octet-stream']}
+                    onDrop={(files) => form.setFieldValue('files', [...form.getValues().files, ...files])}
+                    onReject={() => setError('rpmファイルのみアップロードできます')}
+                    disabled={loading}
+                >
                     <Group justify="center" gap="xl" mih={120} style={{ pointerEvents: 'none' }}>
                         <Dropzone.Accept><IconDownload size={52} color="var(--mantine-color-blue-6)" stroke={1.5} /></Dropzone.Accept>
                         <Dropzone.Reject><IconX size={52} color="var(--mantine-color-red-6)" stroke={1.5} /></Dropzone.Reject>


### PR DESCRIPTION
### Motivation
- Users could not select or drag-and-drop RPM files because the Dropzone `accept` list did not include the `.rpm` extension or some common RPM MIME types, causing the file picker to reject RPMs.

### Description
- Update `src/app/rpm/upload.tsx` to expand the `Dropzone` `accept` prop to include `'.rpm'`, `application/x-rpm`, `application/x-redhat-package-manager`, and retain `application/octet-stream`, and reformat the Dropzone props for readability.

### Testing
- Ran `npm run lint`, which completed successfully with only existing unrelated warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9937c9440832a97bcb9609c8daffd)