### PR TITLE
Add custom RPM repository support for downloads and optional TLS-skip for RPM uploads

### DIFF
--- a/src/app/api/rpm/start/route.ts
+++ b/src/app/api/rpm/start/route.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import { nanoid } from 'nanoid';
 import { jobStore } from '@/lib/jobStore';
 import { ProgressBus, globalBusMap } from '@/lib/progressBus';
-import { buildRpmBundle } from '@/lib/rpm/downloader';
+import { buildRpmBundle, RPM_REPO_PRESETS, type RpmRepository } from '@/lib/rpm/downloader';
 import { uploadFileToS3 } from '@/lib/storage/s3';
 import { logRequest } from '@/lib/requestLog';
 
@@ -11,15 +11,63 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
 
+function normalizeCustomRepositories(input: unknown): RpmRepository[] {
+    if (!Array.isArray(input)) return [];
+    const customRepos: RpmRepository[] = [];
+    for (let i = 0; i < input.length; i += 1) {
+        const entry = input[i] as Record<string, unknown>;
+        const baseUrl = typeof entry?.baseUrl === 'string' ? entry.baseUrl.trim() : '';
+        if (!baseUrl) continue;
+        if (!/^https?:\/\//i.test(baseUrl)) {
+            throw new Error(`customRepositories[${i}] baseUrl must start with http:// or https://`);
+        }
+
+        const idRaw = typeof entry?.id === 'string' ? entry.id.trim() : '';
+        const labelRaw = typeof entry?.label === 'string' ? entry.label.trim() : '';
+        const folderRaw = typeof entry?.folderName === 'string' ? entry.folderName.trim() : '';
+        const generated = `custom-repo-${i + 1}`;
+        customRepos.push({
+            id: idRaw || generated,
+            label: labelRaw || idRaw || generated,
+            folderName: folderRaw || labelRaw || idRaw || generated,
+            baseUrl: baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`,
+        });
+    }
+    return customRepos;
+}
+
 export async function POST(req: NextRequest) {
     const body = await req.json();
     const packages = Array.isArray(body.packages) ? body.packages.map((s: any) => String(s).trim()).filter(Boolean) : [];
     const bundleName = typeof body.bundleName === 'string' && body.bundleName.trim() ? body.bundleName.trim() : 'rpm-offline';
-    const repositories = Array.isArray(body.repositories) ? body.repositories.map((s: any) => String(s).trim()).filter(Boolean) : [];
+    const repositoryIds = Array.isArray(body.repositories) ? body.repositories.map((s: any) => String(s).trim()).filter(Boolean) : [];
     const resolveDependencies = body.resolveDependencies !== false;
 
     if (!packages.length) {
         return new Response(JSON.stringify({ error: 'packages[] is required' }), { status: 400 });
+    }
+
+    let repositories: RpmRepository[];
+    try {
+        const presetRepos = RPM_REPO_PRESETS.filter((repo) => repositoryIds.includes(repo.id));
+        const customRepos = normalizeCustomRepositories(body.customRepositories);
+        const usedIds = new Set<string>();
+        repositories = [...presetRepos, ...customRepos].map((repo) => {
+            let nextId = repo.id;
+            let suffix = 2;
+            while (usedIds.has(nextId)) {
+                nextId = `${repo.id}-${suffix}`;
+                suffix += 1;
+            }
+            usedIds.add(nextId);
+            return { ...repo, id: nextId };
+        });
+    } catch (err: any) {
+        return new Response(JSON.stringify({ error: err?.message || 'invalid customRepositories' }), { status: 400 });
+    }
+
+    if (!repositories.length) {
+        return new Response(JSON.stringify({ error: 'at least one repository is required' }), { status: 400 });
     }
 
     const jobId = nanoid();
@@ -39,7 +87,7 @@ export async function POST(req: NextRequest) {
             const { tarPath, filename, workRoot: root } = await buildRpmBundle({
                 specs: packages,
                 bundleName,
-                selectedRepos: repositories,
+                repositories,
                 resolveDependencies,
                 bus,
             });

--- a/src/app/api/rpm/upload/route.ts
+++ b/src/app/api/rpm/upload/route.ts
@@ -21,6 +21,7 @@ export async function POST(req: NextRequest) {
     const password = searchParams.get('password') || undefined;
     const token = searchParams.get('token')?.trim() || searchParams.get('authToken')?.trim() || undefined;
     const method = ((searchParams.get('method') || 'put').toLowerCase() === 'post' ? 'post' : 'put') as RpmUploadMethod;
+    const ignoreTlsVerify = ['1', 'true', 'yes', 'on'].includes((searchParams.get('ignoreTlsVerify') || '').toLowerCase());
 
     if (!jobId) return new Response(JSON.stringify({ error: 'missing jobId' }), { status: 400 });
     if (!repositoryUrl) return new Response(JSON.stringify({ error: 'missing repositoryUrl' }), { status: 400 });
@@ -89,7 +90,7 @@ export async function POST(req: NextRequest) {
             jobStore.set(jobId, { status: 'running', filename: file.name });
             bus.emitEvent({ type: 'item-start', scope: 'rpm-publish', index: file.index, digest: file.name });
             try {
-                await uploadRpmFile({ filePath: file.tmpPath, repositoryUrl, method, username, password, token });
+                await uploadRpmFile({ filePath: file.tmpPath, repositoryUrl, method, username, password, token, ignoreTlsVerify });
                 successes.push({ name: file.name, index: file.index });
                 bus.emitEvent({ type: 'item-done', scope: 'rpm-publish', index: file.index });
             } catch (err: any) {

--- a/src/app/rpm/download.tsx
+++ b/src/app/rpm/download.tsx
@@ -16,6 +16,42 @@ const repoOptions = [
 
 type Status = 'idle' | 'starting' | 'running' | 'done' | 'error';
 
+type CustomRepo = {
+    id?: string;
+    label?: string;
+    folderName?: string;
+    baseUrl: string;
+};
+
+function parseCustomRepositories(input: string): { repositories: CustomRepo[]; errors: string[] } {
+    const lines = input
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+    const repositories: CustomRepo[] = [];
+    const errors: string[] = [];
+    lines.forEach((line, index) => {
+        const cols = line.split('|').map((part) => part.trim());
+        const [id, label, baseUrl] = cols.length >= 3 ? cols : ['', cols[0] || '', cols[0] || ''];
+        if (!baseUrl) {
+            errors.push(`${index + 1}行目: URLが空です`);
+            return;
+        }
+        if (!/^https?:\/\//i.test(baseUrl)) {
+            errors.push(`${index + 1}行目: URLは http:// または https:// で始めてください`);
+            return;
+        }
+        repositories.push({
+            id: id || undefined,
+            label: label || undefined,
+            folderName: label || id || undefined,
+            baseUrl,
+        });
+    });
+    return { repositories, errors };
+}
+
 export function DownloadPane() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -33,11 +69,20 @@ export function DownloadPane() {
             packages: '',
             bundleName: 'rpm-offline',
             repositories: repoOptions.map((o) => o.value),
+            customRepositories: '',
             resolveDependencies: true,
         },
         validate: {
             packages: (v) => (v.trim() ? null : 'rpm package名を入力してください'),
-            repositories: (v) => (v.length ? null : 'リポジトリを1つ以上選択してください'),
+            repositories: (v, values) => {
+                if (v.length) return null;
+                const { repositories } = parseCustomRepositories(values.customRepositories);
+                return repositories.length ? null : 'リポジトリを1つ以上選択/入力してください';
+            },
+            customRepositories: (v) => {
+                const parsed = parseCustomRepositories(v);
+                return parsed.errors[0] ?? null;
+            },
         },
     });
 
@@ -70,6 +115,10 @@ export function DownloadPane() {
 
         try {
             const specs = values.packages.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+            const customRepositoriesParsed = parseCustomRepositories(values.customRepositories);
+            if (customRepositoriesParsed.errors.length) {
+                throw new Error(customRepositoriesParsed.errors[0]);
+            }
             const res = await fetch('/api/rpm/start', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -77,6 +126,7 @@ export function DownloadPane() {
                     packages: specs,
                     bundleName: values.bundleName,
                     repositories: values.repositories,
+                    customRepositories: customRepositoriesParsed.repositories,
                     resolveDependencies: values.resolveDependencies,
                 }),
             });
@@ -140,6 +190,15 @@ export function DownloadPane() {
                     <Checkbox.Group label="Repositories" key={form.key('repositories')} {...form.getInputProps('repositories')}>
                         <Stack mt="xs">{repoOptions.map((repo) => <Checkbox key={repo.value} value={repo.value} label={repo.label} />)}</Stack>
                     </Checkbox.Group>
+                    <Textarea
+                        label="Custom repositories"
+                        description="1行1件。URLのみ、または `id|label|url` 形式で入力"
+                        placeholder={'https://download.example.com/rhel/8/BaseOS/x86_64/os/\ncustom-rhel8-appstream|RHEL 8 AppStream|https://download.example.com/rhel/8/AppStream/x86_64/os/'}
+                        minRows={3}
+                        key={form.key('customRepositories')}
+                        {...form.getInputProps('customRepositories')}
+                        disabled={loading}
+                    />
                     <Checkbox label="依存関係もダウンロード (--resolve --alldeps)" key={form.key('resolveDependencies')} {...form.getInputProps('resolveDependencies', { type: 'checkbox' })} />
                     <Space h="md" />
                     <Button size="lg" radius="lg" type="submit" loading={loading}>Download</Button>

--- a/src/app/rpm/page.tsx
+++ b/src/app/rpm/page.tsx
@@ -14,6 +14,7 @@ type RpmEnv = {
     RPM_UPLOAD_PASSWORD: string;
     RPM_UPLOAD_TOKEN: string;
     RPM_UPLOAD_METHOD: string;
+    RPM_UPLOAD_IGNORE_TLS_VERIFY: string;
 };
 
 export default function RpmPage() {
@@ -24,6 +25,7 @@ export default function RpmPage() {
         RPM_UPLOAD_PASSWORD: '',
         RPM_UPLOAD_TOKEN: '',
         RPM_UPLOAD_METHOD: 'put',
+        RPM_UPLOAD_IGNORE_TLS_VERIFY: '',
     });
 
     useEffect(() => {
@@ -35,6 +37,7 @@ export default function RpmPage() {
                 RPM_UPLOAD_PASSWORD: vars.RPM_UPLOAD_PASSWORD ?? '',
                 RPM_UPLOAD_TOKEN: vars.RPM_UPLOAD_TOKEN ?? '',
                 RPM_UPLOAD_METHOD: vars.RPM_UPLOAD_METHOD ?? 'put',
+                RPM_UPLOAD_IGNORE_TLS_VERIFY: vars.RPM_UPLOAD_IGNORE_TLS_VERIFY ?? '',
             });
         });
     }, []);

--- a/src/app/rpm/upload.tsx
+++ b/src/app/rpm/upload.tsx
@@ -4,7 +4,7 @@ import { PackageUploadModal } from '@/components/PackageUpload/Modal';
 import { FileItem } from '@/components/Upload/FileItem';
 import { ProgressEvent } from '@/lib/progressBus';
 import { useRetryableEventSource } from '@/lib/useRetryableEventSource';
-import { Accordion, Alert, Button, Group, PasswordInput, Radio, Space, Stack, Text, TextInput } from '@mantine/core';
+import { Accordion, Alert, Button, Checkbox, Group, PasswordInput, Radio, Space, Stack, Text, TextInput } from '@mantine/core';
 import { Dropzone } from '@mantine/dropzone';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
@@ -19,6 +19,7 @@ type EnvProps = {
     RPM_UPLOAD_PASSWORD: string;
     RPM_UPLOAD_TOKEN: string;
     RPM_UPLOAD_METHOD: string;
+    RPM_UPLOAD_IGNORE_TLS_VERIFY: string;
 };
 
 type PerFileState = { received: number; total?: number; status: string };
@@ -30,6 +31,7 @@ type FormValues = {
     password: string;
     token: string;
     method: 'put' | 'post';
+    ignoreTlsVerify: boolean;
 };
 
 const FLUSH_INTERVAL = 250;
@@ -75,6 +77,7 @@ export function UploadPane({ env }: { env: EnvProps }) {
             password: env.RPM_UPLOAD_PASSWORD || '',
             token: env.RPM_UPLOAD_TOKEN || '',
             method: env.RPM_UPLOAD_METHOD === 'post' ? 'post' : 'put',
+            ignoreTlsVerify: ['1', 'true', 'yes', 'on'].includes((env.RPM_UPLOAD_IGNORE_TLS_VERIFY || '').toLowerCase()),
         },
     });
 
@@ -152,6 +155,7 @@ export function UploadPane({ env }: { env: EnvProps }) {
         if (current.username.trim()) params.set('username', current.username.trim());
         if (current.password) params.set('password', current.password);
         if (current.token.trim()) params.set('token', current.token.trim());
+        if (current.ignoreTlsVerify) params.set('ignoreTlsVerify', 'true');
 
         try {
             const res = await fetch(`/api/rpm/upload?${params.toString()}`, { method: 'POST', body: fd });
@@ -199,6 +203,7 @@ export function UploadPane({ env }: { env: EnvProps }) {
                     <TextInput label="Username" key={form.key('username')} {...form.getInputProps('username')} disabled={loading} />
                     <PasswordInput label="Password" key={form.key('password')} {...form.getInputProps('password')} disabled={loading} />
                     <PasswordInput label="Bearer Token" key={form.key('token')} {...form.getInputProps('token')} disabled={loading} />
+                    <Checkbox label="証明書の検証を無視する (curl --insecure)" key={form.key('ignoreTlsVerify')} {...form.getInputProps('ignoreTlsVerify', { type: 'checkbox' })} disabled={loading} />
                 </Stack></Accordion.Panel></Accordion.Item></Accordion>
 
                 <Space h="md" />

--- a/src/lib/rpm/downloader.ts
+++ b/src/lib/rpm/downloader.ts
@@ -12,6 +12,13 @@ export type RpmRepoPreset = {
     baseUrl: string;
 };
 
+export type RpmRepository = {
+    id: string;
+    label: string;
+    folderName: string;
+    baseUrl: string;
+};
+
 export const RPM_REPO_PRESETS: RpmRepoPreset[] = [
     { id: 'centos-stream-9-baseos', label: 'CentOS Stream 9 BaseOS (official)', folderName: 'CentOS Stream BaseOS', baseUrl: 'https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/' },
     { id: 'centos-stream-9-appstream', label: 'CentOS Stream 9 AppStream (official)', folderName: 'CentOS Stream AppStream', baseUrl: 'https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/' },
@@ -21,7 +28,7 @@ export const RPM_REPO_PRESETS: RpmRepoPreset[] = [
 type BuildRpmBundleOptions = {
     specs: string[];
     bundleName?: string;
-    selectedRepos: string[];
+    repositories: RpmRepository[];
     resolveDependencies?: boolean;
     bus: ProgressBus;
 };
@@ -136,7 +143,7 @@ async function queryRepoId(nevra: RpmNevra, repoIds: string[], repoqueryCmd: 'dn
     return first || undefined;
 }
 
-async function buildManifestAndLayout(files: string[], packagesDir: string, outputByRepoRoot: string, repos: RpmRepoPreset[], repoqueryCmd: 'dnf'|'dnf5', bus: ProgressBus): Promise<RpmPackage[]> {
+async function buildManifestAndLayout(files: string[], packagesDir: string, outputByRepoRoot: string, repos: RpmRepository[], repoqueryCmd: 'dnf'|'dnf5', bus: ProgressBus): Promise<RpmPackage[]> {
     const repoIds = repos.map((r) => r.id);
     const repoMap = new Map(repos.map((r) => [r.id, r]));
     const manifest: RpmPackage[] = [];
@@ -176,13 +183,13 @@ async function buildManifestAndLayout(files: string[], packagesDir: string, outp
     return manifest;
 }
 
-export async function buildRpmBundle({ specs, bundleName = 'rpm-offline', selectedRepos, resolveDependencies = true, bus }: BuildRpmBundleOptions) {
+export async function buildRpmBundle({ specs, bundleName = 'rpm-offline', repositories, resolveDependencies = true, bus }: BuildRpmBundleOptions) {
     if (!specs.length) throw new Error('specs is required');
     const { downloadCmd, repoqueryCmd } = await resolveRpmCommands();
     bus.emitEvent({ type: 'stage', stage: 'rpm-prepare' });
     bus.emitEvent({ type: 'log', level: 'info', message: `RPMツール利用可否チェック完了: download=${downloadCmd}, repoquery=${repoqueryCmd}` });
 
-    const repos = RPM_REPO_PRESETS.filter((repo) => selectedRepos.includes(repo.id));
+    const repos = repositories;
     if (!repos.length) throw new Error('at least one repository must be selected');
     bus.emitEvent({ type: 'log', level: 'info', message: `有効リポジトリ: ${repos.map((r) => r.id).join(', ')}` });
 

--- a/src/lib/rpm/publish.ts
+++ b/src/lib/rpm/publish.ts
@@ -9,14 +9,16 @@ export type UploadRpmOptions = {
     username?: string;
     password?: string;
     token?: string;
+    ignoreTlsVerify?: boolean;
 };
 
-export async function uploadRpmFile({ filePath, repositoryUrl, method = 'put', username, password, token }: UploadRpmOptions) {
+export async function uploadRpmFile({ filePath, repositoryUrl, method = 'put', username, password, token, ignoreTlsVerify = false }: UploadRpmOptions) {
     const normalizedBase = repositoryUrl.endsWith('/') ? repositoryUrl : `${repositoryUrl}/`;
     const filename = filePath.split('/').pop() || 'package.rpm';
     const targetUrl = `${normalizedBase}${encodeURIComponent(filename)}`;
 
     const args: string[] = ['--silent', '--show-error', '--fail', '--location', '-X', method.toUpperCase()];
+    if (ignoreTlsVerify) args.push('--insecure');
 
     if (token) {
         args.push('-H', `Authorization: Bearer ${token}`);


### PR DESCRIPTION
### Motivation
- Allow downloading RPMs from arbitrary repositories (not just the built-in RHEL9 presets) so packages for other RHEL streams or custom mirrors can be fetched. 
- Provide an option to skip TLS certificate verification for RPM uploads to work with internal registries that use self-signed certificates.

### Description
- Accept explicit repository definitions end-to-end by introducing `RpmRepository` and changing `buildRpmBundle` to accept a `repositories` array instead of preset IDs, and pass each repo to `dnf` via `--repofrompath` (changes in `src/lib/rpm/downloader.ts`).
- Add a multiline `Custom repositories` input (supports `URL` or `id|label|url` per line) on the download UI with parsing/validation and send parsed entries as `customRepositories` to the start API (changes in `src/app/rpm/download.tsx`).
- Update the RPM start API to validate/normalize `customRepositories`, merge them with selected preset repos, ensure unique repo IDs, and pass the combined repository list to the bundle builder (changes in `src/app/api/rpm/start/route.ts`).
- Add an ignore-TLS option for uploads that flows from UI -> API -> curl by adding `ignoreTlsVerify` to the upload form and environment defaults, parsing it in the upload API, and passing it into `uploadRpmFile` which adds `--insecure` to `curl` when enabled (changes in `src/app/rpm/upload.tsx`, `src/app/api/rpm/upload/route.ts`, `src/lib/rpm/publish.ts`, `src/app/rpm/page.tsx`).

### Testing
- Ran `npm run lint` and it completed successfully; unrelated existing ESLint warnings remain but no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9970bee40832a89fb57604fe91d94)