### PR TITLE
Add Hugging Face model downloader with Ollama-focused UX

### DIFF
--- a/src/app/api/hf/start/route.ts
+++ b/src/app/api/hf/start/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server';
+import fs from 'node:fs/promises';
+import { nanoid } from 'nanoid';
+import { jobStore } from '@/lib/jobStore';
+import { ProgressBus, globalBusMap } from '@/lib/progressBus';
+import { buildHfBundle } from '@/lib/hf/downloader';
+import { uploadFileToS3 } from '@/lib/storage/s3';
+import { logRequest } from '@/lib/requestLog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+function normalizePatterns(input: unknown, fallback: string[]) {
+    if (!Array.isArray(input)) return fallback;
+    const rows = input.map((item) => String(item).trim()).filter(Boolean);
+    return rows.length ? rows : fallback;
+}
+
+export async function POST(req: NextRequest) {
+    const body = await req.json();
+    const repoId = typeof body.repoId === 'string' ? body.repoId.trim() : '';
+    const revision = typeof body.revision === 'string' && body.revision.trim() ? body.revision.trim() : 'main';
+    const bundleName = typeof body.bundleName === 'string' && body.bundleName.trim() ? body.bundleName.trim() : undefined;
+    const token = typeof body.token === 'string' && body.token.trim() ? body.token.trim() : undefined;
+    const includePatterns = normalizePatterns(body.includePatterns, ['*.gguf', '*.json', 'tokenizer*', '*.model']);
+    const excludePatterns = normalizePatterns(body.excludePatterns, []);
+
+    if (!repoId) {
+        return new Response(JSON.stringify({ error: 'repoId is required' }), { status: 400 });
+    }
+
+    const jobId = nanoid();
+    const bus = new ProgressBus();
+    jobStore.set(jobId, { status: 'queued' });
+    globalBusMap.set(jobId, bus);
+    bus.emitEvent({ type: 'stage', stage: 'queued' });
+
+    logRequest(req, `hf:start job=${jobId}`);
+
+    (async () => {
+        let workRoot: string | undefined;
+        try {
+            jobStore.set(jobId, { status: 'running' });
+            const { tarPath, filename, workRoot: root } = await buildHfBundle({
+                repoId,
+                revision,
+                bundleName,
+                includePatterns,
+                excludePatterns,
+                token,
+                bus,
+            });
+            workRoot = root;
+
+            const objectKey = `${jobId}/${filename}`;
+            bus.emitEvent({ type: 'stage', stage: 'uploading-s3' });
+            await uploadFileToS3({ filePath: tarPath, key: objectKey, contentType: 'application/x-tar' });
+            jobStore.set(jobId, { status: 'done', filename, objectKey });
+        } catch (err: any) {
+            jobStore.set(jobId, { status: 'error', error: err?.message || 'failed' });
+            bus.emitEvent({ type: 'error', message: err?.message || 'failed' });
+        } finally {
+            if (workRoot) {
+                try { await fs.rm(workRoot, { recursive: true, force: true }); } catch {}
+            }
+        }
+    })();
+
+    return new Response(JSON.stringify({ jobId }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}

--- a/src/app/hf/download.tsx
+++ b/src/app/hf/download.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { ProgressEvent } from '@/lib/progressBus';
+import { Alert, Badge, Button, Card, Group, Loader, Modal, PasswordInput, Progress, ScrollArea, Space, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { IconCircleCheck, IconDownload, IconInfoCircle } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type Status = 'idle' | 'starting' | 'running' | 'done' | 'error';
+
+type HfFileItem = {
+    path: string;
+    size?: number;
+};
+
+type FileState = {
+    received: number;
+    total?: number;
+    status: 'waiting' | 'downloading' | 'done';
+};
+
+type FormValues = {
+    repoId: string;
+    revision: string;
+    bundleName: string;
+    includePatterns: string;
+    excludePatterns: string;
+    token: string;
+};
+
+export function DownloadPane() {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [status, setStatus] = useState<Status>('idle');
+    const [jobId, setJobId] = useState<string | null>(null);
+    const [files, setFiles] = useState<HfFileItem[]>([]);
+    const [fileState, setFileState] = useState<Record<number, FileState>>({});
+    const [opened, { open, close }] = useDisclosure(false);
+    const esRef = useRef<EventSource | null>(null);
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            repoId: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+            revision: 'main',
+            bundleName: '',
+            includePatterns: '*.gguf\n*.json\ntokenizer*\n*.model',
+            excludePatterns: '*.safetensors',
+            token: '',
+        },
+        validate: {
+            repoId: (value) => (value.trim() ? null : 'repoId は必須です'),
+        },
+    });
+
+    const totals = useMemo(() => {
+        return Object.values(fileState).reduce((acc, item) => {
+            acc.received += item.received || 0;
+            acc.total += item.total || 0;
+            return acc;
+        }, { received: 0, total: 0 });
+    }, [fileState]);
+
+    const progress = totals.total > 0 ? Math.min(100, Math.floor((totals.received / totals.total) * 100)) : 0;
+
+    const reset = useCallback(() => {
+        setStatus('idle');
+        setJobId(null);
+        setFiles([]);
+        setFileState({});
+        esRef.current?.close();
+        esRef.current = null;
+    }, []);
+
+    const cleanupAndDelete = useCallback((targetJobId: string | null) => {
+        if (!targetJobId) return;
+        (async () => {
+            try {
+                await fetch(`/api/build/delete?jobId=${targetJobId}`, { method: 'POST' });
+            } catch {}
+        })();
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            esRef.current?.close();
+        };
+    }, []);
+
+    const handleProgress = useCallback((event: ProgressEvent) => {
+        if (event.type === 'stage') {
+            if (event.stage === 'queued') setStatus('starting');
+            else if (event.stage.startsWith('hf') || event.stage === 'uploading-s3') setStatus('running');
+            return;
+        }
+
+        if (event.type === 'manifest-resolved') {
+            const items = (event.items as HfFileItem[]).map((item) => ({ path: item.path, size: item.size }));
+            setFiles(items);
+            setFileState((prev) => {
+                const next: Record<number, FileState> = { ...prev };
+                items.forEach((item, index) => {
+                    if (!next[index]) {
+                        next[index] = { received: 0, total: item.size, status: 'waiting' };
+                    }
+                });
+                return next;
+            });
+            return;
+        }
+
+        if (event.type === 'item-start' && event.scope === 'hf-download') {
+            setFileState((prev) => ({
+                ...prev,
+                [event.index]: {
+                    received: prev[event.index]?.received ?? 0,
+                    total: event.total ?? prev[event.index]?.total,
+                    status: 'downloading',
+                },
+            }));
+            return;
+        }
+
+        if (event.type === 'item-progress' && event.scope === 'hf-download') {
+            setFileState((prev) => ({
+                ...prev,
+                [event.index]: {
+                    received: event.received,
+                    total: event.total ?? prev[event.index]?.total,
+                    status: 'downloading',
+                },
+            }));
+            return;
+        }
+
+        if (event.type === 'item-done' && event.scope === 'hf-download') {
+            setFileState((prev) => ({
+                ...prev,
+                [event.index]: {
+                    received: prev[event.index]?.total ?? prev[event.index]?.received ?? 0,
+                    total: prev[event.index]?.total,
+                    status: 'done',
+                },
+            }));
+            return;
+        }
+
+        if (event.type === 'done') {
+            setStatus('done');
+            return;
+        }
+
+        if (event.type === 'error') {
+            setStatus('error');
+            setError(event.message);
+        }
+    }, []);
+
+    const submit = form.onSubmit(async (values) => {
+        setError(null);
+        setLoading(true);
+        setStatus('starting');
+        setFiles([]);
+        setFileState({});
+        open();
+
+        try {
+            const includePatterns = values.includePatterns
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(Boolean);
+            const excludePatterns = values.excludePatterns
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(Boolean);
+
+            const res = await fetch('/api/hf/start', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    repoId: values.repoId.trim(),
+                    revision: values.revision.trim() || 'main',
+                    bundleName: values.bundleName.trim() || undefined,
+                    includePatterns,
+                    excludePatterns,
+                    token: values.token.trim() || undefined,
+                }),
+            });
+
+            const payload = await res.json();
+            if (!res.ok) {
+                throw new Error(payload.error || 'start failed');
+            }
+
+            const nextJobId = payload.jobId as string;
+            setJobId(nextJobId);
+
+            esRef.current?.close();
+            const es = new EventSource(`/api/build/progress?jobId=${nextJobId}`);
+            esRef.current = es;
+            es.onmessage = (msg) => {
+                try {
+                    const data = JSON.parse(msg.data) as ProgressEvent;
+                    handleProgress(data);
+                } catch (err) {
+                    console.error(err);
+                }
+            };
+            es.onerror = () => {
+                es.close();
+            };
+        } catch (err: any) {
+            setStatus('error');
+            setError(err?.message || '開始に失敗しました');
+        } finally {
+            setLoading(false);
+        }
+    });
+
+    const closeModal = () => {
+        const current = jobId;
+        close();
+        reset();
+        cleanupAndDelete(current);
+    };
+
+    return (
+        <>
+            <form onSubmit={submit}>
+                <Stack>
+                    <TextInput label="Model Repo ID" placeholder="Qwen/Qwen2.5-0.5B-Instruct-GGUF" required {...form.getInputProps('repoId')} />
+                    <Group grow>
+                        <TextInput label="Revision" placeholder="main" {...form.getInputProps('revision')} />
+                        <TextInput label="Bundle name (optional)" placeholder="qwen2.5-local" {...form.getInputProps('bundleName')} />
+                    </Group>
+                    <Textarea label="Include patterns (1行1パターン)" minRows={4} autosize {...form.getInputProps('includePatterns')} />
+                    <Textarea label="Exclude patterns (1行1パターン)" minRows={2} autosize {...form.getInputProps('excludePatterns')} />
+                    <PasswordInput label="Hugging Face Token (gated modelのみ必要)" placeholder="hf_xxx" {...form.getInputProps('token')} />
+                    {error && (
+                        <Alert color="red" title="Error">{error}</Alert>
+                    )}
+                    <Alert icon={<IconInfoCircle size={16} />} color="teal" variant="light" title="Ollama 連携のヒント">
+                        GGUF を含むパターンを指定してダウンロードすると、同梱の README-OLLAMA.md をそのまま手順書として使えます。
+                    </Alert>
+                    <Button type="submit" loading={loading} radius="lg" color="teal" leftSection={<IconDownload size="1em" />}>
+                        Hugging Face から取得開始
+                    </Button>
+                </Stack>
+            </form>
+
+            <Modal opened={opened} onClose={closeModal} size="lg" centered title="ダウンロード進捗" radius="lg">
+                <Stack>
+                    <Group justify="space-between">
+                        <Badge color={status === 'done' ? 'green' : status === 'error' ? 'red' : 'gray'} leftSection={status === 'done' ? <IconCircleCheck size="1em" /> : status === 'running' || status === 'starting' ? <Loader size="xs" color="white" /> : undefined}>
+                            {status}
+                        </Badge>
+                        {jobId && <Text size="xs" c="dimmed">jobId: {jobId}</Text>}
+                    </Group>
+                    <Progress value={progress} radius="xl" size="lg" />
+                    <Text size="xs" c="dimmed">{(totals.received / 1_000_000).toFixed(2)}MB / {(totals.total / 1_000_000).toFixed(2)}MB</Text>
+                    <ScrollArea h={320}>
+                        <Stack gap="xs">
+                            {files.map((file, index) => {
+                                const state = fileState[index];
+                                const itemProgress = state?.total ? Math.min(100, Math.floor(((state.received || 0) / state.total) * 100)) : 0;
+                                return (
+                                    <Card withBorder key={`${file.path}-${index}`}>
+                                        <Stack gap={4}>
+                                            <Group justify="space-between">
+                                                <Text size="sm" lineClamp={1}>{file.path}</Text>
+                                                <Badge size="xs" color={state?.status === 'done' ? 'green' : state?.status === 'downloading' ? 'blue' : 'gray'}>{state?.status ?? 'waiting'}</Badge>
+                                            </Group>
+                                            <Progress value={itemProgress} size="sm" radius="xl" />
+                                        </Stack>
+                                    </Card>
+                                );
+                            })}
+                        </Stack>
+                    </ScrollArea>
+
+                    <Button
+                        component="a"
+                        href={jobId ? `/api/build/download?jobId=${jobId}` : '#'}
+                        target="_blank"
+                        disabled={!jobId || status !== 'done'}
+                        leftSection={<IconDownload size="1em" />}
+                        radius="lg"
+                        color="dark"
+                        fullWidth
+                    >
+                        tar をダウンロード
+                    </Button>
+                </Stack>
+            </Modal>
+
+            <Space h="md" />
+        </>
+    );
+}

--- a/src/app/hf/page.tsx
+++ b/src/app/hf/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { DownloadPane } from './download';
+import { Group, Space, Text, ThemeIcon, Title } from '@mantine/core';
+import { IconBrain } from '@tabler/icons-react';
+
+export default function HuggingFacePage() {
+    return (
+        <div>
+            <Group justify="space-between">
+                <Title>Hugging Face model</Title>
+                <ThemeIcon variant="transparent" size={60} color="teal">
+                    <IconBrain style={{ width: '70%', height: '70%' }} stroke={1.3} />
+                </ThemeIcon>
+            </Group>
+            <Text c="dimmed">
+                Hugging Face からモデルをまとめて取得し、Ollama などのローカル推論環境で使える tar アーカイブを生成します。
+            </Text>
+
+            <Space h="xl" />
+            <DownloadPane />
+            <Space h="xl" />
+        </div>
+    );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ManagerCatalog, type ManagerEntry } from "@/components/ManagerCatalog";
 import { Center, Container, Space, Stack, Title } from "@mantine/core";
-import { IconBrandDocker, IconBrandNpm, IconBrandPython, IconBox } from "@tabler/icons-react";
+import { IconBrandDocker, IconBrandNpm, IconBrandPython, IconBox, IconBrain } from "@tabler/icons-react";
 import Image from "next/image";
 
 const managers: ManagerEntry[] = [
@@ -28,6 +28,14 @@ const managers: ManagerEntry[] = [
         href: "/pip",
         Icon: IconBrandPython,
         color: "violet",
+    },
+    {
+        id: "hf",
+        name: "Hugging Face model",
+        description: "Hugging Face から GGUF など必要なファイルだけを選択して取得し、Ollama 等のローカル実行に使えるアーカイブを生成できます。",
+        href: "/hf",
+        Icon: IconBrain,
+        color: "teal",
     },
     {
         id: "rpm",

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -32,6 +32,12 @@ export const AppNavbar = () => {
             </Anchor>
             <Anchor
                 className={classes.link}
+                href="/hf"
+            >
+                huggingface
+            </Anchor>
+            <Anchor
+                className={classes.link}
                 href="/admin"
             >
                 管理

--- a/src/lib/hf/downloader.ts
+++ b/src/lib/hf/downloader.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as tar from 'tar';
+import { ProgressBus, type HfFile } from '@/lib/progressBus';
+
+type HfSibling = {
+    rfilename: string;
+    size?: number;
+};
+
+type HfDownloadOptions = {
+    repoId: string;
+    revision?: string;
+    bundleName?: string;
+    includePatterns?: string[];
+    excludePatterns?: string[];
+    token?: string;
+    bus: ProgressBus;
+};
+
+function toSafeBundleName(input: string) {
+    return input
+        .replace(/[^a-zA-Z0-9._@-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '') || 'hf-model';
+}
+
+function wildcardToRegExp(pattern: string) {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.')}$`);
+}
+
+function matchAnyPattern(target: string, patterns: string[]) {
+    if (!patterns.length) return true;
+    return patterns.some((pattern) => wildcardToRegExp(pattern).test(target));
+}
+
+async function fetchModelFileList(repoId: string, token?: string): Promise<HfSibling[]> {
+    const headers: HeadersInit = token ? { Authorization: `Bearer ${token}` } : {};
+    const res = await fetch(`https://huggingface.co/api/models/${encodeURIComponent(repoId)}?expand[]=siblings`, {
+        headers,
+        cache: 'no-store',
+    });
+
+    if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        throw new Error(`Hugging Face API error (${res.status}): ${detail || 'failed to fetch model metadata'}`);
+    }
+
+    const payload = await res.json() as { siblings?: HfSibling[] };
+    return Array.isArray(payload.siblings) ? payload.siblings : [];
+}
+
+async function downloadSingleFile({ repoId, revision, token, relativePath, outPath, bus, index, total }: {
+    repoId: string;
+    revision: string;
+    token?: string;
+    relativePath: string;
+    outPath: string;
+    bus: ProgressBus;
+    index: number;
+    total?: number;
+}) {
+    const headers: HeadersInit = token ? { Authorization: `Bearer ${token}` } : {};
+    const encodedFilePath = relativePath.split('/').map((part) => encodeURIComponent(part)).join('/');
+    const url = `https://huggingface.co/${repoId}/resolve/${encodeURIComponent(revision)}/${encodedFilePath}?download=true`;
+
+    bus.emitEvent({ type: 'item-start', scope: 'hf-download', index, digest: relativePath, total });
+
+    const res = await fetch(url, { headers, redirect: 'follow', cache: 'no-store' });
+    if (!res.ok || !res.body) {
+        const detail = await res.text().catch(() => '');
+        throw new Error(`failed to download ${relativePath}: ${res.status} ${detail}`);
+    }
+
+    await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
+    const stream = fs.createWriteStream(outPath);
+    const reader = res.body.getReader();
+
+    let received = 0;
+    while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        stream.write(Buffer.from(value));
+        received += value.byteLength;
+        bus.emitEvent({ type: 'item-progress', scope: 'hf-download', index, received, total });
+    }
+
+    await new Promise<void>((resolve, reject) => {
+        stream.end(() => resolve());
+        stream.on('error', reject);
+    });
+
+    bus.emitEvent({ type: 'item-done', scope: 'hf-download', index });
+}
+
+export async function buildHfBundle({
+    repoId,
+    revision = 'main',
+    bundleName,
+    includePatterns = ['*.gguf', '*.json', 'tokenizer*', '*.model'],
+    excludePatterns = [],
+    token,
+    bus,
+}: HfDownloadOptions) {
+    if (!repoId.trim()) throw new Error('repoId is required');
+
+    bus.emitEvent({ type: 'stage', stage: 'hf-resolve-model' });
+    const siblings = await fetchModelFileList(repoId, token);
+
+    const files = siblings
+        .filter((item) => !!item.rfilename)
+        .filter((item) => matchAnyPattern(item.rfilename, includePatterns))
+        .filter((item) => !matchAnyPattern(item.rfilename, excludePatterns));
+
+    if (!files.length) {
+        throw new Error('download target files are empty. Please check include / exclude patterns.');
+    }
+
+    const manifest: HfFile[] = files.map((item) => ({
+        path: item.rfilename,
+        size: item.size,
+    }));
+    bus.emitEvent({ type: 'manifest-resolved', items: manifest });
+
+    const resolvedBundleName = toSafeBundleName(bundleName?.trim() || `${repoId.replace('/', '--')}@${revision}`);
+    const workRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hfdl-'));
+    const bundleRoot = path.join(workRoot, resolvedBundleName, 'huggingface');
+    const modelRoot = path.join(bundleRoot, 'models', repoId.replace('/', '--'), revision);
+    await fs.promises.mkdir(modelRoot, { recursive: true });
+
+    bus.emitEvent({ type: 'stage', stage: 'hf-download' });
+    for (let i = 0; i < files.length; i += 1) {
+        const file = files[i];
+        const outPath = path.join(modelRoot, file.rfilename);
+        await downloadSingleFile({
+            repoId,
+            revision,
+            token,
+            relativePath: file.rfilename,
+            outPath,
+            bus,
+            index: i,
+            total: file.size,
+        });
+    }
+
+    const guide = `# Hugging Face Model Bundle\n\n- Repository: ${repoId}\n- Revision: ${revision}\n- Files: ${files.length}\n\n## Example: run with Ollama\n\n1. Pick a downloaded ".gguf" file path in this archive.\n2. Create Modelfile:\n\n\`\`\`\nFROM ./path/to/model.gguf\n\`\`\`\n\n3. Build and run:\n\n\`\`\`bash\nollama create local-${resolvedBundleName} -f Modelfile\nollama run local-${resolvedBundleName}\n\`\`\`\n`;
+    await fs.promises.writeFile(path.join(bundleRoot, 'README-OLLAMA.md'), guide, 'utf8');
+    await fs.promises.writeFile(path.join(bundleRoot, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+
+    bus.emitEvent({ type: 'tar-writing' });
+    const filename = `${resolvedBundleName}.tar`;
+    const tarPath = path.join(workRoot, filename);
+    await tar.c({ cwd: path.join(workRoot, resolvedBundleName), file: tarPath, sync: true }, ['.']);
+    bus.emitEvent({ type: 'done', filename });
+
+    return { tarPath, filename, workRoot, manifest };
+}

--- a/src/lib/progressBus.ts
+++ b/src/lib/progressBus.ts
@@ -40,10 +40,15 @@ export type RpmPackage = {
     repositoryFolder?: string;
 };
 
+export type HfFile = {
+    path: string;
+    size?: number;
+};
+
 export type ProgressEvent =
     | { type: "stage"; stage: string }
     | { type: "repo-tag-resolved"; items: RepoTag[]} // docker imageのrepoとtagを解決したときに送るやつ
-    | { type: "manifest-resolved"; manifestName?: string; items: Layer[]|LockEntry[]|PipPackage[]|RpmPackage[] }
+    | { type: "manifest-resolved"; manifestName?: string; items: Layer[]|LockEntry[]|PipPackage[]|RpmPackage[]|HfFile[] }
     | { type: 'item-start'; index: number; scope?: string; manifestName?: string; digest: string; total?: number }
     | { type: 'item-progress'; index: number; scope?: string; manifestName?: string; received: number; total?: number }
     | { type: 'item-done'; scope?: string; manifestName?: string; index: number }


### PR DESCRIPTION
### Motivation
- Provide a simple end-to-end flow to download Hugging Face model files (GGUF, tokenizer, metadata, etc.), package them into a tar usable by local runners like `ollama`, and surface progress in the existing SSE-based UI.
- Make it easy to fetch gated models by allowing an optional HF token and flexible include/exclude wildcard patterns so users can select only the needed artifacts.

### Description
- Added a new frontend page and UI for Hugging Face at `src/app/hf/page.tsx` with a `DownloadPane` in `src/app/hf/download.tsx` that accepts `repoId`, `revision`, `includePatterns`, `excludePatterns`, and an optional token and shows per-file and overall SSE progress.
- Implemented backend orchestration endpoint `POST /api/hf/start` in `src/app/api/hf/start/route.ts` which enqueues a job, wires a `ProgressBus`, invokes the downloader, uploads the resulting tar to S3 via `uploadFileToS3`, and records job state in `jobStore`.
- Added the Hugging Face downloader logic in `src/lib/hf/downloader.ts` which resolves model siblings from the HF API, filters by wildcard patterns, streams each file with progress events, generates `manifest.json` and `README-OLLAMA.md`, and packs the bundle into a tar archive.
- Extended progress event typings in `src/lib/progressBus.ts` with a new `HfFile` type and allowed `manifest-resolved` to carry HF manifests, and exposed the new manager entry from the top catalog and navbar (`src/app/page.tsx`, `src/components/Navbar/index.tsx`).

### Testing
- Ran lint with `npm run lint`, which executed successfully and reported only existing warnings unrelated to the new HF flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99dfcdb74832a9e000a1f19eb2cd6)