### PR TITLE
Fix RPM upload to preserve original filenames

### DIFF
--- a/src/app/api/rpm/upload/route.ts
+++ b/src/app/api/rpm/upload/route.ts
@@ -90,7 +90,7 @@ export async function POST(req: NextRequest) {
             jobStore.set(jobId, { status: 'running', filename: file.name });
             bus.emitEvent({ type: 'item-start', scope: 'rpm-publish', index: file.index, digest: file.name });
             try {
-                await uploadRpmFile({ filePath: file.tmpPath, repositoryUrl, method, username, password, token, ignoreTlsVerify });
+                await uploadRpmFile({ filePath: file.tmpPath, fileName: file.name, repositoryUrl, method, username, password, token, ignoreTlsVerify });
                 successes.push({ name: file.name, index: file.index });
                 bus.emitEvent({ type: 'item-done', scope: 'rpm-publish', index: file.index });
             } catch (err: any) {

--- a/src/lib/rpm/publish.ts
+++ b/src/lib/rpm/publish.ts
@@ -4,6 +4,7 @@ export type RpmUploadMethod = 'put' | 'post';
 
 export type UploadRpmOptions = {
     filePath: string;
+    fileName?: string;
     repositoryUrl: string;
     method?: RpmUploadMethod;
     username?: string;
@@ -12,9 +13,9 @@ export type UploadRpmOptions = {
     ignoreTlsVerify?: boolean;
 };
 
-export async function uploadRpmFile({ filePath, repositoryUrl, method = 'put', username, password, token, ignoreTlsVerify = false }: UploadRpmOptions) {
+export async function uploadRpmFile({ filePath, fileName, repositoryUrl, method = 'put', username, password, token, ignoreTlsVerify = false }: UploadRpmOptions) {
     const normalizedBase = repositoryUrl.endsWith('/') ? repositoryUrl : `${repositoryUrl}/`;
-    const filename = filePath.split('/').pop() || 'package.rpm';
+    const filename = fileName || filePath.split('/').pop() || 'package.rpm';
     const targetUrl = `${normalizedBase}${encodeURIComponent(filename)}`;
 
     const args: string[] = ['--silent', '--show-error', '--fail', '--location', '-X', method.toUpperCase()];


### PR DESCRIPTION
### Motivation
- Ensure uploaded RPMs use the original uploaded filename instead of the temporary `timestamp-index-name` path to avoid numeric suffixes in the repository.

### Description
- Add an optional `fileName` field to `UploadRpmOptions` and use it in `uploadRpmFile`, and update the RPM upload API route to pass the original `file.name` when calling `uploadRpmFile`, while keeping the fallback to derive the filename from `filePath` when `fileName` is not provided.

### Testing
- Ran `npm run lint`, which completed successfully (only existing unrelated warnings remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da39f13d54832aa7e041b6e1fee383)