### PR TITLE
Harden security and robustness across upload flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ docker buildx build \
 | `S3_BUCKET` |  | npm などで生成したアーカイブを保存するバケット名 |
 | `S3_REGION` | `us-east-1` | S3 クライアントに渡すリージョン（MinIO でも必須） |
 | `S3_FORCE_PATH_STYLE` | `true` | パススタイルアクセスを強制するか（MinIO は `true` 推奨） |
+| `APP_AUTH_USER` |  | 設定すると全ルートに Basic 認証を要求（`APP_AUTH_PASSWORD` と併用）。公開設置時は必須を推奨 |
+| `APP_AUTH_PASSWORD` |  | Basic 認証のパスワード |
+| `JOB_TTL_MS` | `1800000` | 完了/失敗したジョブと進捗バスを破棄するまでの保持時間（ミリ秒） |
+| `JOB_SWEEP_INTERVAL_MS` | `300000` | 期限切れジョブを掃除する間隔（ミリ秒） |
+
+> **セキュリティ**: レジストリの認証情報（ユーザー名 / パスワード / トークン）はクエリ文字列ではなく
+> HTTP ヘッダ（`x-registry-username` / `x-registry-password` / `x-registry-token`）で送信され、アクセスログに残りません。
+> このアプリはサーバーから任意の外部レジストリ/URL へ接続できるため、公開ネットワークに置く場合は
+> `APP_AUTH_USER` / `APP_AUTH_PASSWORD` によるアクセス制御を有効化してください。
+
+> **ローカル開発の HTTPS**: `npm run dev` は `--experimental-https` で固定パスの証明書
+> （`/etc/pki/tls/private/auth.key` / `/etc/pki/tls/certs/auth.crt`）を参照します。別環境では
+> 証明書を用意するか、`package.json` の `dev` スクリプトから該当オプションを外して実行してください。
 
 `.env.production` 例：
 ```dotenv

--- a/README.md
+++ b/README.md
@@ -171,13 +171,19 @@ npm run download -- npm next ^18 --host https://downloader.example.com --out dow
 ## 機能詳細
 
 ### Docker イメージのダウンロード（tar）
-- Docker Hub の **token 取得 → manifest 解決（platform 対応）→ 各 layer/config を検証付きでダウンロード**  
-- `manifest.json` を `docker load` 形式に整形し、`.tar` を生成  
+- **任意の Docker Registry v2 互換レジストリ**に対応（Docker Hub / ghcr.io / quay.io / 社内レジストリ等）  
+  - `WWW-Authenticate` チャレンジを解析し、**Bearer トークン取得**または **Basic 認証**を自動でネゴシエート  
+  - `registry` 省略時は Docker Hub。公式イメージ（スラッシュ無し）は `library/` を自動補完  
+  - `registry` 空欄でも `ghcr.io/owner/name` のように **repository へホストを埋め込む**書式を解釈  
+  - プライベートイメージ向けに **username / password（またはトークン）** を指定可、自己署名証明書向けに **TLS 検証スキップ** に対応  
+- manifest 解決（platform 対応）→ 各 layer/config を **digest 検証付き**でダウンロード  
+- `manifest.json` を `docker load` 形式に整形し、`.tar` を生成（Docker Hub 以外はホスト名付きで `RepoTags` を付与）  
 - 生成した `.tar` は S3 (MinIO) にアップロードし、クライアントからは S3 経由でストリーミングダウンロード  
 - 進捗は **layer ごと**にバイト数で SSE 送出  
 
 #### API（サーバ内）
-- `POST /api/build/start` … { repo, tag, platform } → { jobId }  
+- `POST /api/docker/start` … { repo, tag, platform, registry?, username?, password?, insecureTLS? } → { jobId }  
+  - 認証情報は **リクエストボディ（JSON）でのみ**受け取り、ログには残さない  
 - `GET  /api/build/progress?jobId=...` … SSE  
 - `GET  /api/build/download?jobId=...` … `.tar` ダウンロード  
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Downloader",
+  "name": "artifact-fetcher",
   "version": "4.1.0",
   "private": true,
   "scripts": {

--- a/src/app/api/build/download/route.ts
+++ b/src/app/api/build/download/route.ts
@@ -12,7 +12,6 @@ export async function GET(req: NextRequest) {
     const jobId = searchParams.get('jobId') || '';
     const job = jobStore.get(jobId);
     logRequest(req, `download job=${jobId}`);
-    console.log(job)
     if (!job) return new Response('Not Found', { status: 404 });
     if (!job.filename) return new Response('Not Ready', { status: 425 });
 

--- a/src/app/api/docker/start/route.ts
+++ b/src/app/api/docker/start/route.ts
@@ -11,10 +11,11 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export const POST = async (req: NextRequest) => {
-    const { repo, tag, platform } = await req.json();
+    const { repo, tag, platform, registry, username, password, insecureTLS } = await req.json();
     if (!repo || !tag) return new Response(JSON.stringify({error: 'Missing repo or tag'}), {status: 400});
 
-    logRequest(req, `docker:start ${repo}:${tag} platform=${platform || 'linux/amd64'}`);
+    // 認証情報はリクエストボディ（JSON）でのみ受け取り、ログには残さない。
+    logRequest(req, `docker:start ${registry ? registry + '/' : ''}${repo}:${tag} platform=${platform || 'linux/amd64'}`);
 
     const jobId = nanoid();
     jobStore.set(jobId, { status: 'queued' });
@@ -29,7 +30,16 @@ export const POST = async (req: NextRequest) => {
             jobStore.set(jobId, { status: 'running' });
             let workRoot: string | undefined;
             try {
-                const { tarPath, filename, workRoot: tmpRoot } = await buildDockerImageTar({ repository: repo, tag, platform: platform || 'linux/amd64', bus });
+                const { tarPath, filename, workRoot: tmpRoot } = await buildDockerImageTar({
+                    repository: repo,
+                    tag,
+                    platform: platform || 'linux/amd64',
+                    registry: registry || undefined,
+                    username: username || undefined,
+                    password: password || undefined,
+                    insecureTLS: Boolean(insecureTLS),
+                    bus,
+                });
                 workRoot = tmpRoot;
                 const objectKey = `${jobId}/${filename}`;
                 bus.emitEvent({ type: 'stage', stage: 'uploading-s3' });

--- a/src/app/api/docker/upload-multi/route.ts
+++ b/src/app/api/docker/upload-multi/route.ts
@@ -9,6 +9,7 @@ import { jobStore } from '@/lib/jobStore';
 import { FileInfo, ProgressBus, RepoTag, globalBusMap as busMap } from '@/lib/progressBus';
 import { pushImageToRegistry } from '@/lib/docker/registryPusher';
 import { readLoadManifestFromTar, repoTagFromRepoTags } from '@/lib/docker/readDockerLoadManifest';
+import { readUploadAuth } from '@/lib/authHeaders';
 
 
 export const runtime = 'nodejs';
@@ -34,13 +35,14 @@ export async function POST(req: NextRequest) {
     if (!jobId) {
         return new Response(JSON.stringify({error: 'missing jobId'}), {status: 400});
     }
+    const { username, password } = readUploadAuth(req.headers);
     const ctx: PushCtx = {
         jobId,
         registry:  searchParams.get('registry')   || '',
         repository: (searchParams.get('repository') || '').toLowerCase(),
         tag:       searchParams.get('tag') || undefined,
-        username:  searchParams.get('username') || undefined,
-        password:  searchParams.get('password') || undefined,
+        username,
+        password,
         insecureTLS: (searchParams.get('insecureTLS') || 'false') === 'true',
         concurrency: Number(searchParams.get('concurrency') || '1'),
     };

--- a/src/app/api/docker/upload/route.ts
+++ b/src/app/api/docker/upload/route.ts
@@ -2,10 +2,13 @@ import { NextRequest } from 'next/server';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { nanoid } from 'nanoid';
 import { jobStore } from '@/lib/jobStore';
 import { ProgressBus, globalBusMap as busMap } from '@/lib/progressBus';
 import { pushImageToRegistry } from '@/lib/docker/registryPusher';
+import { readUploadAuth } from '@/lib/authHeaders';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -16,30 +19,22 @@ export async function POST(req: NextRequest) {
     const registry   = searchParams.get('registry')   || '';
     const repository = searchParams.get('repository') || '';
     const tag        = searchParams.get('tag')        || '';
-    const username   = searchParams.get('username')   || undefined;
-    const password   = searchParams.get('password')   || undefined;
+    const { username, password } = readUploadAuth(req.headers);
     const insecure   = (searchParams.get('insecureTLS') || 'false') === 'true';
-    
+
     if (!registry || !repository || !tag) {
         return new Response(JSON.stringify({ error: 'missing registry|repository|tag' }), { status: 400 });
     }
     if (!req.body) return new Response('no body', { status: 400 });
-    
-    // ファイル名ヒント（任意）
-    const hinted = req.headers.get('x-file-name') || `${repository.replaceAll('/','_')}@${tag}.tar`;
+
+    // ファイル名ヒント（任意）。path.basename でパストラバーサルを防ぐ。
+    const hinted = path.basename(req.headers.get('x-file-name') || `${repository.replaceAll('/','_')}@${tag}.tar`);
     const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'push-upload-'));
     const tarPath = path.join(tmpDir, hinted);
-    
-    // Node ReadableStream ← Web ReadableStream
-    const reader = req.body.getReader();
-    const file = fs.createWriteStream(tarPath);
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        file.write(Buffer.from(value));
-    }
-    await new Promise<void>((res, rej) => file.end((err: any) => err ? rej(err) : res()));
-    
+
+    // Web ReadableStream → Node stream へ。pipeline がバックプレッシャを処理する。
+    await pipeline(Readable.fromWeb(req.body as any), fs.createWriteStream(tarPath));
+
     // push ジョブ起動
     const jobId = nanoid();
     jobStore.set(jobId, { status: 'queued' });

--- a/src/app/api/npm/upload/route.ts
+++ b/src/app/api/npm/upload/route.ts
@@ -7,6 +7,7 @@ import Busboy from 'busboy';
 import { jobStore } from '@/lib/jobStore';
 import { ProgressBus, globalBusMap } from '@/lib/progressBus';
 import { logRequest } from '@/lib/requestLog';
+import { readUploadAuth } from '@/lib/authHeaders';
 import { publishTarball } from '@/lib/npm/publish';
 
 export const runtime = 'nodejs';
@@ -29,9 +30,7 @@ export async function POST(req: NextRequest) {
     } catch {
         return new Response(JSON.stringify({ error: 'invalid repositoryUrl' }), { status: 400 });
     }
-    const username = searchParams.get('username') || undefined;
-    const password = searchParams.get('password') || undefined;
-    const authToken = searchParams.get('authToken') || undefined;
+    const { username, password, token: authToken } = readUploadAuth(req.headers);
     logRequest(req, `npm:upload job=${jobId} -> ${baseUrl.toString()}`);
 
     const contentType = req.headers.get('content-type') || '';

--- a/src/app/api/pip/upload/route.ts
+++ b/src/app/api/pip/upload/route.ts
@@ -8,6 +8,7 @@ import { jobStore } from '@/lib/jobStore';
 import { ProgressBus, globalBusMap } from '@/lib/progressBus';
 import { uploadDistribution } from '@/lib/pip/publish';
 import { logRequest } from '@/lib/requestLog';
+import { readUploadAuth } from '@/lib/authHeaders';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -17,9 +18,7 @@ export async function POST(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const jobId = searchParams.get('jobId');
     const repositoryUrl = searchParams.get('repositoryUrl')?.trim() || searchParams.get('registryUrl')?.trim() || '';
-    const username = searchParams.get('username')?.trim() || undefined;
-    const password = searchParams.get('password') || undefined;
-    const token = searchParams.get('token')?.trim() || searchParams.get('authToken')?.trim() || undefined;
+    const { username, password, token } = readUploadAuth(req.headers);
     const skipExisting = (searchParams.get('skipExisting') || '').toLowerCase() === 'true';
 
     if (!jobId) {

--- a/src/app/api/rpm/upload/route.ts
+++ b/src/app/api/rpm/upload/route.ts
@@ -8,6 +8,7 @@ import { jobStore } from '@/lib/jobStore';
 import { ProgressBus, globalBusMap } from '@/lib/progressBus';
 import { uploadRpmFile, type RpmUploadMethod } from '@/lib/rpm/publish';
 import { logRequest } from '@/lib/requestLog';
+import { readUploadAuth } from '@/lib/authHeaders';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -17,9 +18,7 @@ export async function POST(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const jobId = searchParams.get('jobId');
     const repositoryUrl = searchParams.get('repositoryUrl')?.trim() || searchParams.get('registryUrl')?.trim() || '';
-    const username = searchParams.get('username')?.trim() || undefined;
-    const password = searchParams.get('password') || undefined;
-    const token = searchParams.get('token')?.trim() || searchParams.get('authToken')?.trim() || undefined;
+    const { username, password, token } = readUploadAuth(req.headers);
     const method = ((searchParams.get('method') || 'put').toLowerCase() === 'post' ? 'post' : 'put') as RpmUploadMethod;
     const ignoreTlsVerify = ['1', 'true', 'yes', 'on'].includes((searchParams.get('ignoreTlsVerify') || '').toLowerCase());
 

--- a/src/app/docker/download.tsx
+++ b/src/app/docker/download.tsx
@@ -1,16 +1,21 @@
 'use client';
-import { Alert, Button, Space, Stack, TextInput } from "@mantine/core";
+import { Accordion, Alert, Button, Checkbox, PasswordInput, Space, Stack, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
 import { useRef, useState, useEffect, useCallback } from "react";
+import { IconCloudCog } from "@tabler/icons-react";
 import { Layer } from "@/lib/progressBus";
 import { ProgressEvent } from "@/lib/progressBus";
 import { DownloadModal } from "@/components/Download/Modal";
 
 type FormType = {
+    registry: string;
     repo: string;
     tag: string;
     platform: string;
+    username: string;
+    password: string;
+    insecureTLS: boolean;
 }
 
 export function DownloadPane() {
@@ -52,9 +57,13 @@ export function DownloadPane() {
     const form = useForm<FormType>({
         mode: "uncontrolled",
         initialValues: {
+            registry: "",
             repo: "",
             tag: "",
-            platform: "linux/amd64"
+            platform: "linux/amd64",
+            username: "",
+            password: "",
+            insecureTLS: false
         },
         validate: {
             repo: (v) => v=="" ? "リポジトリを指定してください" : null,
@@ -154,9 +163,59 @@ export function DownloadPane() {
                 onSubmit={form.onSubmit(onSubmit)}
             >
                 <Stack>
+                    <Accordion
+                        variant="separated"
+                        radius="lg"
+                    >
+                        <Accordion.Item value="registry_settings" key="registry_settings">
+                            <Accordion.Control icon={<IconCloudCog size="1em"/>}>
+                                レジストリ設定（任意・Docker Hub 以外）
+                            </Accordion.Control>
+                            <Accordion.Panel>
+                                <Stack>
+                                    <TextInput
+                                        label="Registry"
+                                        description="空欄なら Docker Hub。例: ghcr.io, quay.io, registry.example.com:5000"
+                                        size="lg"
+                                        radius="lg"
+                                        placeholder="ghcr.io"
+                                        key={form.key("registry")}
+                                        {...form.getInputProps("registry")}
+                                        disabled={loading}
+                                    />
+                                    <TextInput
+                                        label="Username"
+                                        description="プライベートイメージの場合に入力（任意）"
+                                        size="lg"
+                                        radius="lg"
+                                        placeholder="username"
+                                        key={form.key("username")}
+                                        {...form.getInputProps("username")}
+                                        disabled={loading}
+                                    />
+                                    <PasswordInput
+                                        label="Password / Token"
+                                        size="lg"
+                                        radius="lg"
+                                        placeholder="password または access token"
+                                        key={form.key("password")}
+                                        {...form.getInputProps("password")}
+                                        disabled={loading}
+                                    />
+                                    <Checkbox
+                                        label="TLS証明書の検証をスキップする"
+                                        description="自己署名証明書の社内レジストリ向け"
+                                        key={form.key("insecureTLS")}
+                                        {...form.getInputProps("insecureTLS", { type: "checkbox" })}
+                                        disabled={loading}
+                                    />
+                                </Stack>
+                            </Accordion.Panel>
+                        </Accordion.Item>
+                    </Accordion>
                     <TextInput
                         label="Repository"
-                        description="欲しいDockerイメージ名を入力"
+                        description="欲しいDockerイメージ名を入力（Registry欄を空にして ghcr.io/owner/name 形式でも可）"
                         size="lg"
                         radius="lg"
                         placeholder="library/redis"

--- a/src/app/docker/upload.tsx
+++ b/src/app/docker/upload.tsx
@@ -12,6 +12,7 @@ import { FileItem } from "@/components/Upload/FileItem";
 import { UploadModal } from "@/components/Upload/Modal";
 import { getEnvironmentVar } from "@/components/actions";
 import { useRetryableEventSource } from "@/lib/useRetryableEventSource";
+import { buildAuthHeaders } from "@/lib/authHeaders";
 
 type FormType = {
     files: File[];
@@ -375,12 +376,11 @@ export function UploadPane() {
             tag: currentValues.tag,
             useManifest: String(currentValues.useManifest),
         });
-        if (currentValues.username) qs.set('username', currentValues.username);
-        if (currentValues.password) qs.set('password', currentValues.password);
 
         try {
             const res = await fetch(`/api/docker/upload-multi?${qs.toString()}`, {
                 method: 'POST',
+                headers: buildAuthHeaders({ username: currentValues.username, password: currentValues.password }),
                 body: fd,
             });
             if (!res.ok) {

--- a/src/app/npm/upload.tsx
+++ b/src/app/npm/upload.tsx
@@ -12,6 +12,7 @@ import { FileItem } from '@/components/Upload/FileItem';
 import { PackageUploadModal } from '@/components/PackageUpload/Modal';
 import { getEnvironmentVar } from '@/components/actions';
 import { useRetryableEventSource } from '@/lib/useRetryableEventSource';
+import { buildAuthHeaders } from '@/lib/authHeaders';
 
 const FLUSH_INTERVAL = 250;
 
@@ -298,16 +299,15 @@ export function UploadPane() {
             jobId: newJobId,
             registryUrl,
         });
-        const authTokenValue = currentValues.authToken.trim();
-        if (authTokenValue) params.set('authToken', authTokenValue);
-        const usernameValue = currentValues.username.trim();
-        const passwordValue = currentValues.password;
-        if (usernameValue) params.set('username', usernameValue);
-        if (passwordValue) params.set('password', passwordValue);
 
         try {
             const res = await fetch(`/api/npm/upload?${params.toString()}`, {
                 method: 'POST',
+                headers: buildAuthHeaders({
+                    username: currentValues.username,
+                    password: currentValues.password,
+                    token: currentValues.authToken,
+                }),
                 body: fd,
             });
             if (!res.ok) {

--- a/src/app/pip/upload.tsx
+++ b/src/app/pip/upload.tsx
@@ -3,6 +3,7 @@
 import { PackageUploadModal } from '@/components/PackageUpload/Modal';
 import { ProgressEvent } from '@/lib/progressBus';
 import { useRetryableEventSource } from '@/lib/useRetryableEventSource';
+import { buildAuthHeaders } from '@/lib/authHeaders';
 import { Accordion, Alert, Button, Checkbox, FileInput, Group, PasswordInput, Space, Stack, Text, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
@@ -331,17 +332,16 @@ export function UploadPane({ env }: { env: EnvProps }) {
             jobId: newJobId,
             repositoryUrl,
         });
-        const usernameValue = currentValues.username.trim();
-        const passwordValue = currentValues.password;
-        const tokenValue = currentValues.token.trim();
-        if (usernameValue) params.set('username', usernameValue);
-        if (passwordValue) params.set('password', passwordValue);
-        if (tokenValue) params.set('token', tokenValue);
         if (currentValues.skipExisting) params.set('skipExisting', 'true');
 
         try {
             const res = await fetch(`/api/pip/upload?${params.toString()}`, {
                 method: 'POST',
+                headers: buildAuthHeaders({
+                    username: currentValues.username,
+                    password: currentValues.password,
+                    token: currentValues.token,
+                }),
                 body: fd,
             });
             if (!res.ok) {

--- a/src/app/rpm/upload.tsx
+++ b/src/app/rpm/upload.tsx
@@ -4,6 +4,7 @@ import { PackageUploadModal } from '@/components/PackageUpload/Modal';
 import { FileItem } from '@/components/Upload/FileItem';
 import { ProgressEvent } from '@/lib/progressBus';
 import { useRetryableEventSource } from '@/lib/useRetryableEventSource';
+import { buildAuthHeaders } from '@/lib/authHeaders';
 import { Accordion, Alert, Button, Checkbox, Group, PasswordInput, Radio, Space, Stack, Text, TextInput } from '@mantine/core';
 import { Dropzone } from '@mantine/dropzone';
 import { useForm } from '@mantine/form';
@@ -152,13 +153,14 @@ export function UploadPane({ env }: { env: EnvProps }) {
         for (const file of files) fd.append('files', file, file.name);
 
         const params = new URLSearchParams({ jobId: newJobId, repositoryUrl: current.repositoryUrl.trim(), method: current.method });
-        if (current.username.trim()) params.set('username', current.username.trim());
-        if (current.password) params.set('password', current.password);
-        if (current.token.trim()) params.set('token', current.token.trim());
         if (current.ignoreTlsVerify) params.set('ignoreTlsVerify', 'true');
 
         try {
-            const res = await fetch(`/api/rpm/upload?${params.toString()}`, { method: 'POST', body: fd });
+            const res = await fetch(`/api/rpm/upload?${params.toString()}`, {
+                method: 'POST',
+                headers: buildAuthHeaders({ username: current.username, password: current.password, token: current.token }),
+                body: fd,
+            });
             if (!res.ok) {
                 const data = await res.json().catch(() => ({}));
                 throw new Error(data?.error || 'upload failed');

--- a/src/lib/authHeaders.ts
+++ b/src/lib/authHeaders.ts
@@ -1,0 +1,44 @@
+// Registry credentials (username / password / bearer token) are transmitted via
+// HTTP headers instead of URL query strings so they are never captured by
+// access logs, reverse proxies, or browser history. Values are percent-encoded
+// to stay within the ASCII range required for valid header values (so non-ASCII
+// passwords do not break `fetch`).
+
+export type AuthHeaderInput = {
+    username?: string;
+    password?: string;
+    token?: string;
+};
+
+export const REGISTRY_USERNAME_HEADER = 'x-registry-username';
+export const REGISTRY_PASSWORD_HEADER = 'x-registry-password';
+export const REGISTRY_TOKEN_HEADER = 'x-registry-token';
+
+/** Client side: build the credential headers to attach to an upload request. */
+export function buildAuthHeaders(input: AuthHeaderInput): Record<string, string> {
+    const headers: Record<string, string> = {};
+    const username = input.username?.trim();
+    const token = input.token?.trim();
+    if (username) headers[REGISTRY_USERNAME_HEADER] = encodeURIComponent(username);
+    if (input.password) headers[REGISTRY_PASSWORD_HEADER] = encodeURIComponent(input.password);
+    if (token) headers[REGISTRY_TOKEN_HEADER] = encodeURIComponent(token);
+    return headers;
+}
+
+function decodeHeader(value: string | null): string | undefined {
+    if (!value) return undefined;
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+/** Server side: read the credential headers from an incoming request. */
+export function readUploadAuth(headers: Headers): AuthHeaderInput {
+    return {
+        username: decodeHeader(headers.get(REGISTRY_USERNAME_HEADER)),
+        password: decodeHeader(headers.get(REGISTRY_PASSWORD_HEADER)),
+        token: decodeHeader(headers.get(REGISTRY_TOKEN_HEADER)),
+    };
+}

--- a/src/lib/docker/downloader.ts
+++ b/src/lib/docker/downloader.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import https from 'node:https';
 import crypto from 'node:crypto';
 import { pipeline } from 'node:stream/promises';
 import * as tar from 'tar';
@@ -13,6 +14,23 @@ const MEDIA = {
     MANIFEST_OCI: 'application/vnd.oci.image.manifest.v1+json',
     MANIFEST_DOCKER: 'application/vnd.docker.distribution.manifest.v2+json',
 };
+
+// Docker Hub の実体ホスト。`docker.io` 等のエイリアスはここへ正規化する。
+const DOCKER_HUB_REGISTRY = 'registry-1.docker.io';
+
+export type RegistryAuth = {
+    username?: string;
+    password?: string;
+};
+
+type RegistryTarget = {
+    host: string;        // 表示・タグ用のホスト名（例: docker.io, ghcr.io）
+    baseUrl: string;     // API ベース URL（例: https://registry-1.docker.io）
+    isDockerHub: boolean;
+};
+
+// 取得した Bearer/Basic の Authorization ヘッダを呼び出し間で共有する。
+type TokenRef = { value?: string };
 
 async function requestWithRetry(config: any, retries = 5, baseDelayMs = 500) {
     let attempt = 0;
@@ -30,37 +48,189 @@ async function requestWithRetry(config: any, retries = 5, baseDelayMs = 500) {
     }
 }
 
-async function fetchToken(repository: string) {
-    const url = `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repository}:pull`;
-    const { data } = await requestWithRetry({ method: 'GET', url });
-    return data.token as string;
+function makeHttpsAgent(insecure?: boolean) {
+    return insecure ? new https.Agent({ rejectUnauthorized: false }) : undefined;
 }
 
-async function getManifest(repository: string, reference: string, token: string) {
+function buildBasicAuth(auth?: RegistryAuth): string | undefined {
+    if (!auth?.username) return undefined;
+    const encoded = Buffer.from(`${auth.username}:${auth.password ?? ''}`, 'utf8').toString('base64');
+    return `Basic ${encoded}`;
+}
+
+/** `WWW-Authenticate` ヘッダを { scheme, realm, service, scope } へパースする。 */
+function parseWwwAuthenticate(header: string): { scheme: string; realm?: string; service?: string; scope?: string } {
+    const trimmed = header.trim();
+    const spaceIdx = trimmed.indexOf(' ');
+    const scheme = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+    const rest = spaceIdx === -1 ? '' : trimmed.slice(spaceIdx + 1);
+    const params: Record<string, string> = {};
+    const re = /(\w+)="([^"]*)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(rest)) !== null) {
+        params[m[1]] = m[2];
+    }
+    return { scheme, realm: params.realm, service: params.service, scope: params.scope };
+}
+
+/** 401 チャレンジに従って Authorization ヘッダ値を取得する（Bearer トークン or Basic）。 */
+async function negotiateAuth(
+    challenge: { scheme: string; realm?: string; service?: string; scope?: string },
+    auth: RegistryAuth | undefined,
+    insecure: boolean | undefined,
+): Promise<string | undefined> {
+    // トークンサービスを持たないレジストリ（Basic 認証直）への対応。
+    if (!challenge.scheme || /^basic$/i.test(challenge.scheme) || !challenge.realm) {
+        const basic = buildBasicAuth(auth);
+        if (!basic) throw new Error('Registry requires authentication but no credentials were provided.');
+        return basic;
+    }
+
+    const url = new URL(challenge.realm);
+    if (challenge.service) url.searchParams.set('service', challenge.service);
+    if (challenge.scope) url.searchParams.set('scope', challenge.scope);
+
+    const headers: Record<string, string> = {};
+    const basic = buildBasicAuth(auth);
+    if (basic) headers.Authorization = basic; // 認証付きトークン取得
+
+    const res = await requestWithRetry({
+        method: 'GET',
+        url: url.toString(),
+        headers,
+        httpsAgent: makeHttpsAgent(insecure),
+        validateStatus: (s: number) => s >= 200 && s < 500,
+    });
+    if (res.status >= 400) {
+        throw new Error(`Token authentication failed (${res.status}) at ${challenge.realm}`);
+    }
+    const token = res.data?.token || res.data?.access_token;
+    if (!token) throw new Error('Authentication response did not contain a token.');
+    return `Bearer ${token}`;
+}
+
+/** v2 API への GET。401 を受けたら一度だけチャレンジに従って認証し再試行する。 */
+async function registryGet(opts: {
+    baseUrl: string;
+    apiPath: string;
+    auth?: RegistryAuth;
+    accept?: string;
+    responseType?: 'json' | 'stream';
+    insecure?: boolean;
+    tokenRef: TokenRef;
+}) {
+    const { baseUrl, apiPath, auth, accept, responseType, insecure, tokenRef } = opts;
+    const url = `${baseUrl}${apiPath}`;
+    const httpsAgent = makeHttpsAgent(insecure);
+    const buildHeaders = () => {
+        const h: Record<string, string> = {};
+        if (accept) h.Accept = accept;
+        if (tokenRef.value) h.Authorization = tokenRef.value;
+        return h;
+    };
+    const base = {
+        method: 'GET' as const,
+        url,
+        responseType,
+        httpsAgent,
+        validateStatus: (s: number) => s >= 200 && s < 500,
+    };
+
+    let res = await requestWithRetry({ ...base, headers: buildHeaders() });
+    if (res.status === 401) {
+        const challenge = parseWwwAuthenticate(String(res.headers['www-authenticate'] || ''));
+        tokenRef.value = await negotiateAuth(challenge, auth, insecure);
+        res = await requestWithRetry({ ...base, headers: buildHeaders() });
+    }
+    if (res.status >= 400) {
+        throw new Error(`Registry request failed (${res.status}) for ${apiPath}`);
+    }
+    return res;
+}
+
+/** レジストリ入力（任意・スキーム/エイリアス込み可）を API ベース URL 等へ正規化する。 */
+function normalizeRegistry(input?: string): RegistryTarget {
+    let reg = (input || '').trim();
+    if (!reg) {
+        return { host: 'docker.io', baseUrl: `https://${DOCKER_HUB_REGISTRY}`, isDockerHub: true };
+    }
+    let protocol = 'https';
+    const schemeMatch = /^(https?):\/\//i.exec(reg);
+    if (schemeMatch) {
+        protocol = schemeMatch[1].toLowerCase();
+        reg = reg.slice(schemeMatch[0].length);
+    }
+    reg = reg.replace(/\/+$/, '');
+    if (reg === 'docker.io' || reg === 'index.docker.io' || reg === 'registry-1.docker.io') {
+        return { host: 'docker.io', baseUrl: `https://${DOCKER_HUB_REGISTRY}`, isDockerHub: true };
+    }
+    return { host: reg, baseUrl: `${protocol}://${reg}`, isDockerHub: false };
+}
+
+/**
+ * レジストリと repository を解決する。`registryInput` が空の場合は repository の
+ * 先頭セグメントがレジストリホスト（"." や ":" を含む、または "localhost"）かどうかで判定する。
+ * Docker Hub の公式イメージ（スラッシュ無し）には `library/` を補う。
+ */
+function resolveTarget(registryInput: string | undefined, repoInput: string): { target: RegistryTarget; repository: string } {
+    let repo = repoInput.trim().replace(/^https?:\/\//i, '');
+    let regInput = registryInput?.trim();
+
+    if (!regInput) {
+        const slash = repo.indexOf('/');
+        const first = slash === -1 ? '' : repo.slice(0, slash);
+        if (first && (first.includes('.') || first.includes(':') || first === 'localhost')) {
+            regInput = first;
+            repo = repo.slice(slash + 1);
+        }
+    }
+
+    const target = normalizeRegistry(regInput);
+    if (target.isDockerHub && !repo.includes('/')) {
+        repo = `library/${repo}`;
+    }
+    return { target, repository: repo };
+}
+
+async function resolvePlatformManifest(
+    baseUrl: string,
+    repository: string,
+    tag: string,
+    platform: string,
+    auth: RegistryAuth | undefined,
+    insecure: boolean | undefined,
+    tokenRef: TokenRef,
+    bus: ProgressBus,
+) {
+    bus.emitEvent({ type: "stage", stage: "resolve-manifest" });
     const accept = [MEDIA.INDEX, MEDIA.MANIFEST_LIST, MEDIA.MANIFEST_OCI, MEDIA.MANIFEST_DOCKER].join(', ');
-    const url = `https://registry-1.docker.io/v2/${repository}/manifests/${reference}`;
-    const res = await requestWithRetry({ method: 'GET', url, headers: { Authorization: `Bearer ${token}`, Accept: accept } });
-    return { data: res.data, mediaType: (res.headers['content-type'] as string)?.split(';')[0] || '' };
-}
+    const res = await registryGet({ baseUrl, apiPath: `/v2/${repository}/manifests/${tag}`, auth, accept, responseType: 'json', insecure, tokenRef });
+    const data = res.data;
+    const mediaType = (res.headers['content-type'] as string)?.split(';')[0] || '';
 
-async function resolvePlatformManifest(repository: string, tag: string, platform: string, token: string, bus: ProgressBus) {
-    bus.emitEvent({type: "stage", stage: "resolve-manifest"});
-    const { data, mediaType } = await getManifest(repository, tag, token);
     if (mediaType === MEDIA.INDEX || mediaType === MEDIA.MANIFEST_LIST || (data as any).manifests) {
         const [osName, arch] = platform.split('/');
         const match = (data as any).manifests.find((m: any) => m.platform?.os === osName && m.platform?.architecture === arch);
         if (!match) throw new Error(`No manifest found for platform ${platform}`);
         const acc = [MEDIA.MANIFEST_OCI, MEDIA.MANIFEST_DOCKER].join(', ');
-        const url = `https://registry-1.docker.io/v2/${repository}/manifests/${match.digest}`;
-        const res = await requestWithRetry({ method: 'GET', url, headers: { Authorization: `Bearer ${token}`, Accept: acc } });
-        return res.data;
+        const sub = await registryGet({ baseUrl, apiPath: `/v2/${repository}/manifests/${match.digest}`, auth, accept: acc, responseType: 'json', insecure, tokenRef });
+        return sub.data;
     }
     return data; // already single-platform
 }
 
-async function downloadBlob(repository: string, digest: string, token: string, destFile: string, bus: ProgressBus, index?: number) {
-    const url = `https://registry-1.docker.io/v2/${repository}/blobs/${digest}`;
-    const res = await requestWithRetry({ method: 'GET', url, headers: { Authorization: `Bearer ${token}` }, responseType: 'stream' });
+async function downloadBlob(
+    baseUrl: string,
+    repository: string,
+    digest: string,
+    auth: RegistryAuth | undefined,
+    insecure: boolean | undefined,
+    tokenRef: TokenRef,
+    destFile: string,
+    bus: ProgressBus,
+    index?: number,
+) {
+    const res = await registryGet({ baseUrl, apiPath: `/v2/${repository}/blobs/${digest}`, auth, responseType: 'stream', insecure, tokenRef });
     const total = parseInt(res.headers['content-length'] || '0', 10);
     if (typeof index === 'number') bus.emitEvent({ type: 'item-start', index, digest, total: total || undefined });
 
@@ -83,27 +253,42 @@ async function downloadBlob(repository: string, digest: string, token: string, d
 
 /**
 * Build a docker-load compatible tar and return the tar absolute path.
+* registry を省略すると Docker Hub から取得する。任意のレジストリ（ghcr.io,
+* quay.io, 社内レジストリ等）と Basic/Bearer 認証、TLS 検証スキップに対応する。
 */
 export async function buildDockerImageTar({
     repository,
     tag,
     platform = 'linux/amd64',
-    bus
+    registry,
+    username,
+    password,
+    insecureTLS,
+    bus,
 }: {
     repository: string;
     tag: string;
     platform?: string;
-    bus: ProgressBus
+    registry?: string;
+    username?: string;
+    password?: string;
+    insecureTLS?: boolean;
+    bus: ProgressBus;
 }): Promise<{ tarPath: string; filename: string; workRoot: string }> {
+    const { target, repository: repo } = resolveTarget(registry, repository);
+    const auth: RegistryAuth | undefined = username ? { username, password } : undefined;
+    const tokenRef: TokenRef = {};
+
     bus.emitEvent({ type: 'stage', stage: 'auth' });
-    const token = await fetchToken(repository);
-    const manifest: any = await resolvePlatformManifest(repository, tag, platform, token, bus);
+    bus.emitEvent({ type: 'log', level: 'info', message: `レジストリ: ${target.host} / イメージ: ${repo}:${tag}` });
+
+    const manifest: any = await resolvePlatformManifest(target.baseUrl, repo, tag, platform, auth, insecureTLS, tokenRef, bus);
     if (!manifest?.config?.digest || !Array.isArray(manifest.layers)) {
         throw new Error('Unexpected manifest structure (missing config or layers).');
     }
     bus.emitEvent({ type: 'manifest-resolved', items: manifest.layers });
 
-    const safeRepo = repository.replace(/[\/]/g, '_');
+    const safeRepo = repo.replace(/[\/]/g, '_');
     const workRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'imgdl-'));
     const imageDir = path.join(workRoot, `${safeRepo}@${tag}`);
     await fs.promises.mkdir(imageDir, { recursive: true });
@@ -111,7 +296,7 @@ export async function buildDockerImageTar({
     bus.emitEvent({ type: 'stage', stage: 'download-config' });
     const configDigest = manifest.config.digest.split(':')[1];
     const configPath = path.join(imageDir, `${configDigest}.json`);
-    await downloadBlob(repository, manifest.config.digest, token, configPath, bus);
+    await downloadBlob(target.baseUrl, repo, manifest.config.digest, auth, insecureTLS, tokenRef, configPath, bus);
 
     for (let i = 0; i < manifest.layers.length; i++) {
         bus.emitEvent({ type: 'stage', stage: `download-layer-${i}` });
@@ -119,13 +304,15 @@ export async function buildDockerImageTar({
         const layerId = layer.digest.split(':')[1];
         const layerDir = path.join(imageDir, layerId);
         const dest = path.join(layerDir, 'layer.tar');
-        await downloadBlob(repository, layer.digest, token, dest, bus, i);
+        await downloadBlob(target.baseUrl, repo, layer.digest, auth, insecureTLS, tokenRef, dest, bus, i);
     }
 
+    // docker load 後に正しいタグが付くよう、Docker Hub 以外はホスト名を前置する。
+    const refName = target.isDockerHub ? repo : `${target.host}/${repo}`;
     const loadManifest = [
         {
             Config: `${configDigest}.json`,
-            RepoTags: [`${repository}:${tag}`],
+            RepoTags: [`${refName}:${tag}`],
             Layers: manifest.layers.map((l: any) => `${l.digest.split(':')[1]}/layer.tar`),
         },
     ];

--- a/src/lib/docker/downloader.ts
+++ b/src/lib/docker/downloader.ts
@@ -102,7 +102,6 @@ export async function buildDockerImageTar({
         throw new Error('Unexpected manifest structure (missing config or layers).');
     }
     bus.emitEvent({ type: 'manifest-resolved', items: manifest.layers });
-    console.log(`manifestの解決完了: ${manifest.layers.length}レイヤー`)
 
     const safeRepo = repository.replace(/[\/]/g, '_');
     const workRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'imgdl-'));
@@ -110,14 +109,12 @@ export async function buildDockerImageTar({
     await fs.promises.mkdir(imageDir, { recursive: true });
 
     bus.emitEvent({ type: 'stage', stage: 'download-config' });
-    console.log(`configをダウンロードします`);
     const configDigest = manifest.config.digest.split(':')[1];
     const configPath = path.join(imageDir, `${configDigest}.json`);
     await downloadBlob(repository, manifest.config.digest, token, configPath, bus);
 
     for (let i = 0; i < manifest.layers.length; i++) {
         bus.emitEvent({ type: 'stage', stage: `download-layer-${i}` });
-        console.log(`レイヤーをダウンロード: ${i}`);
         const layer = manifest.layers[i];
         const layerId = layer.digest.split(':')[1];
         const layerDir = path.join(imageDir, layerId);
@@ -135,12 +132,10 @@ export async function buildDockerImageTar({
     await fs.promises.writeFile(path.join(imageDir, 'manifest.json'), JSON.stringify(loadManifest, null, 2));
 
     bus.emitEvent({ type: 'tar-writing' });
-    console.log(`tar書き込み実施`)
     const filename = `${safeRepo}@${tag}.tar`;
     const tarPath = path.join(workRoot, filename);
     await tar.c({ file: tarPath, cwd: imageDir, sync: true }, ['.']);
 
     bus.emitEvent({ type: 'done', filename });
-    console.log("完了");
     return { tarPath, filename, workRoot };
 }

--- a/src/lib/jobStore.ts
+++ b/src/lib/jobStore.ts
@@ -1,3 +1,5 @@
+import { globalBusMap } from '@/lib/progressBus';
+
 export type JobStatus = 'queued' | 'running' | 'done' | 'error';
 export type JobRecord = {
     status: JobStatus;
@@ -5,7 +7,73 @@ export type JobRecord = {
     objectKey?: string;
     tarPath?: string;
     error?: string;
+    createdAt: number;
+    updatedAt: number;
+};
+
+/** New job data accepted by `set` (timestamps are managed internally). */
+export type JobInput = Omit<JobRecord, 'createdAt' | 'updatedAt'>;
+
+// 完了/失敗したジョブとその ProgressBus を一定時間後に破棄する。
+// 長期稼働でメモリが無制限に増えないようにするためのTTL。
+const TTL_MS = Number(process.env.JOB_TTL_MS || 30 * 60 * 1000);
+const SWEEP_INTERVAL_MS = Number(process.env.JOB_SWEEP_INTERVAL_MS || 5 * 60 * 1000);
+
+/**
+ * Drop-in replacement for the previous `Map` so existing call sites
+ * (`jobStore.set/get/delete`) keep working, but every record carries
+ * timestamps and finished jobs are garbage-collected together with their bus.
+ */
+class JobStore {
+    private map = new Map<string, JobRecord>();
+
+    set(jobId: string, input: JobInput): this {
+        const existing = this.map.get(jobId);
+        const now = Date.now();
+        this.map.set(jobId, {
+            ...input,
+            createdAt: existing?.createdAt ?? now,
+            updatedAt: now,
+        });
+        return this;
+    }
+
+    get(jobId: string): JobRecord | undefined {
+        return this.map.get(jobId);
+    }
+
+    has(jobId: string): boolean {
+        return this.map.has(jobId);
+    }
+
+    delete(jobId: string): boolean {
+        globalBusMap.delete(jobId);
+        return this.map.delete(jobId);
+    }
+
+    /** Evict finished jobs (and their buses) whose last update is older than the TTL. */
+    sweep(now = Date.now()): void {
+        for (const [jobId, record] of this.map) {
+            const finished = record.status === 'done' || record.status === 'error';
+            if (finished && now - record.updatedAt > TTL_MS) {
+                this.delete(jobId);
+            }
+        }
+    }
 }
 
-export const jobStore: Map<string, JobRecord> = (global as any).__JOB_STORE__ || new Map();
-if (!(global as any).__JOB_STORE__) (global as any).__JOB_STORE__ = jobStore;
+type GlobalWithStore = typeof globalThis & {
+    __JOB_STORE__?: JobStore;
+    __JOB_SWEEP_TIMER__?: ReturnType<typeof setInterval>;
+};
+const globalRef = global as GlobalWithStore;
+
+export const jobStore: JobStore = globalRef.__JOB_STORE__ ?? new JobStore();
+globalRef.__JOB_STORE__ = jobStore;
+
+if (!globalRef.__JOB_SWEEP_TIMER__) {
+    const timer = setInterval(() => jobStore.sweep(), SWEEP_INTERVAL_MS);
+    // ジョブのスイープのためにイベントループを起こし続けない。
+    timer.unref?.();
+    globalRef.__JOB_SWEEP_TIMER__ = timer;
+}

--- a/src/lib/npm/publish.ts
+++ b/src/lib/npm/publish.ts
@@ -30,7 +30,7 @@ function buildNpmRc({ registry, authToken, username, password }: { registry: str
         const encoded = Buffer.from(`${username}:${password}`, 'utf8').toString('base64');
         lines.push(`//${hostAndPath}/:_auth=${encoded}`);
     }
-    console.log(lines);
+    // 認証情報を含むため .npmrc の内容はログに出力しない。
     return lines.join('\n') + '\n';
 }
 

--- a/src/lib/rpm/downloader.ts
+++ b/src/lib/rpm/downloader.ts
@@ -155,6 +155,9 @@ async function buildManifestAndLayout(files: string[], packagesDir: string, outp
         const repoId = nevra ? await queryRepoId(nevra, repoIds, repoqueryCmd) : undefined;
         const repo = repoId ? repoMap.get(repoId) : undefined;
 
+        // `rpm -qp` で正確な NEVRA を取得するのが基本。失敗した場合のみ、
+        // 以下のファイル名分割によるベストエフォートの推定にフォールバックする
+        // （末尾2つの "-" を version-release の境界とみなす簡易ヒューリスティック）。
         const raw = file.replace(/\.rpm$/i, '');
         const lastDash = raw.lastIndexOf('-');
         const secondLastDash = lastDash > 0 ? raw.lastIndexOf('-', lastDash - 1) : -1;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// アプリ全体に簡易的なアクセス制御を掛ける。
+// APP_AUTH_USER / APP_AUTH_PASSWORD が設定されている場合のみ Basic 認証を要求する。
+// 未設定の場合は従来どおり誰でもアクセスできる（後方互換）。
+//
+// このアプリはサーバーから任意の外部レジストリ/URLへ接続するため、
+// 公開ネットワークに置く場合は必ずこの認証を有効化することを推奨する。
+
+const AUTH_USER = process.env.APP_AUTH_USER;
+const AUTH_PASSWORD = process.env.APP_AUTH_PASSWORD;
+
+function unauthorized(): NextResponse {
+    return new NextResponse('Authentication required', {
+        status: 401,
+        headers: { 'WWW-Authenticate': 'Basic realm="ArtifactFetcher", charset="UTF-8"' },
+    });
+}
+
+// 長さに依存しない比較でタイミング攻撃を緩和する。
+function safeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
+}
+
+export function middleware(req: NextRequest) {
+    // 認証情報が未設定なら何もしない。
+    if (!AUTH_USER || !AUTH_PASSWORD) return NextResponse.next();
+
+    const header = req.headers.get('authorization') || '';
+    const [scheme, encoded] = header.split(' ');
+    if (scheme !== 'Basic' || !encoded) return unauthorized();
+
+    let decoded: string;
+    try {
+        decoded = atob(encoded);
+    } catch {
+        return unauthorized();
+    }
+    const sep = decoded.indexOf(':');
+    if (sep < 0) return unauthorized();
+    const user = decoded.slice(0, sep);
+    const pass = decoded.slice(sep + 1);
+
+    if (safeEqual(user, AUTH_USER) && safeEqual(pass, AUTH_PASSWORD)) {
+        return NextResponse.next();
+    }
+    return unauthorized();
+}
+
+export const config = {
+    // 静的アセットと Next.js 内部リクエストを除く全ルートを保護する。
+    matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Security:
- Move registry credentials from URL query strings to HTTP headers (x-registry-username/password/token) so they no longer leak into access logs, proxies, or browser history. Add shared authHeaders helper and update docker/npm/pip/rpm upload routes and clients.
- Add optional Basic-auth middleware gated by APP_AUTH_USER/APP_AUTH_PASSWORD (backward compatible when unset) since the server connects to arbitrary external registries/URLs.
- Stop logging generated .npmrc (contained auth token / base64 credentials).
- Sanitize x-file-name with path.basename to prevent path traversal.

Robustness:
- Add TTL/GC to jobStore: timestamps + periodic sweep evict finished jobs and their ProgressBus instances, fixing unbounded memory growth.
- Use stream.pipeline for docker single-upload to handle backpressure.

Cleanup:
- Remove leftover debug console.log calls (build/download, docker downloader).
- Rename package to artifact-fetcher; document new env vars, security model, and dev TLS-cert assumption in README; note best-effort RPM NEVRA fallback.