### PR TITLE
Fix upload pipeline: SSE progress race, multipart truncation, and large request bodies

### DIFF
--- a/src/app/api/build/progress/route.ts
+++ b/src/app/api/build/progress/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { globalBusMap } from '@/lib/progressBus';
+import { ProgressBus, globalBusMap } from '@/lib/progressBus';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -7,8 +7,16 @@ export const dynamic = 'force-dynamic';
 export const GET = async (req: NextRequest) => {
     const { searchParams } = new URL(req.url);
     const jobId = searchParams.get('jobId') || '';
-    const bus = globalBusMap.get(jobId);
-    if (!bus) return new Response('Not Found', { status: 404 });
+    if (!jobId) return new Response('Bad Request', { status: 400 });
+
+    // アップロード系のジョブはクライアントが先に SSE へ接続し、その後に
+    // upload-multi などの POST がバスを生成する。接続が先行してもよいよう、
+    // バスが未生成ならここで作成しておく（POST 側は get() で同じバスを再利用する）。
+    let bus = globalBusMap.get(jobId);
+    if (!bus) {
+        bus = new ProgressBus();
+        globalBusMap.set(jobId, bus);
+    }
     
     const stream = new ReadableStream({
         start(controller) {

--- a/src/app/api/docker/upload-multi/route.ts
+++ b/src/app/api/docker/upload-multi/route.ts
@@ -3,7 +3,6 @@ import { NextRequest } from 'next/server';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { Readable } from 'node:stream';
 import Busboy from 'busboy';
 import { jobStore } from '@/lib/jobStore';
 import { FileInfo, ProgressBus, RepoTag, globalBusMap as busMap } from '@/lib/progressBus';
@@ -68,8 +67,7 @@ export async function POST(req: NextRequest) {
     }
     
     const bb = Busboy({ headers: { 'content-type': contentType } });
-    const nodeReadable = Readable.fromWeb(req.body as any);
-    
+
     let uploadIndex = 0;
 
     const finished = new Promise<void>((resolve, reject) => {
@@ -82,7 +80,7 @@ export async function POST(req: NextRequest) {
             const myIndex = uploadIndex++;
             let received = 0;
             bus.emitEvent({type: 'item-start', scope: 'upload', index: myIndex, digest: safeName});
-            
+
             fileStream.on('data', (chunk: Buffer) => {
                 received += chunk.length;
                 bus.emitEvent({type: 'item-progress', scope: 'upload', index: myIndex, received});
@@ -92,21 +90,57 @@ export async function POST(req: NextRequest) {
             })
             fileStream.pipe(ws);
 
-            saves.push(new Promise<void>((resolve, reject) => {
+            const save = new Promise<void>((resolve, reject) => {
               ws.on('finish', resolve);
               ws.on('error', reject);
               fileStream.on('error', reject);
-            }));
+            });
+            // 中断・切断時の未処理 rejection（プロセスごと落とし得る）を防ぐ。
+            // 正常系では下の Promise.all(saves) が同じ rejection を検知する。
+            save.catch(() => {});
+            saves.push(save);
         });
         bb.on('error', reject);
-        bb.on('finish', resolve);
+        bb.on('close', resolve);
     });
-    
-    nodeReadable.pipe(bb);
-    await finished;
-    await Promise.all(saves);
-    
+
+    // Next.js(undici) の req.body(Web ReadableStream) を busboy へ手動で流し込む。
+    // Readable.fromWeb().pipe(bb) ではストリーム終端の伝播が不安定で、全バイトが
+    // 届く前に終端し busboy が "Unexpected end of form" を投げることがあるため、
+    // getReader() で最後まで読み切ってから明示的に bb.end() する。
+    const pump = (async () => {
+        const reader = (req.body as ReadableStream<Uint8Array>).getReader();
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value && value.byteLength) {
+                    // バックプレッシャを尊重し、書き込みが詰まったら drain を待つ。
+                    if (!bb.write(Buffer.from(value))) {
+                        await new Promise<void>((res) => bb.once('drain', res));
+                    }
+                }
+            }
+            bb.end();
+        } catch (err) {
+            bb.destroy(err as Error);
+            throw err;
+        }
+    })();
+
+    try {
+        await Promise.all([finished, pump]);
+        await Promise.all(saves);
+    } catch (err: any) {
+        const message = err?.message || 'failed to receive upload';
+        jobStore.set(jobId, { status: 'error', error: message });
+        bus.emitEvent({ type: 'error', message });
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+        return new Response(JSON.stringify({ error: message }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+
     if (files.length === 0) {
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
         return new Response(JSON.stringify({ error: 'no files' }), { status: 400 });
     }
 

--- a/src/app/api/npm/upload/route.ts
+++ b/src/app/api/npm/upload/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest } from 'next/server';
-import { Readable } from 'node:stream';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -48,7 +47,6 @@ export async function POST(req: NextRequest) {
     jobStore.set(jobId, { status: 'running' });
 
     const bb = Busboy({ headers: { 'content-type': contentType } });
-    const nodeStream = Readable.fromWeb(req.body as any);
     const tmpRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'npm-publish-'));
     const files: Array<{ name: string; tmpPath: string; index: number }> = [];
     const saves: Promise<void>[] = [];
@@ -76,21 +74,45 @@ export async function POST(req: NextRequest) {
             fileStream.on('error', reject);
             ws.on('error', reject);
             fileStream.pipe(ws);
-            saves.push(new Promise<void>((res, rej) => {
+            const save = new Promise<void>((res, rej) => {
                 ws.on('finish', res);
                 ws.on('error', rej);
                 fileStream.on('error', rej);
-            }));
+            });
+            // 中断・切断時の未処理 rejection を防ぐ（正常系は Promise.all(saves) で検知）。
+            save.catch(() => {});
+            saves.push(save);
         });
         bb.on('error', reject);
-        bb.on('finish', resolve);
+        bb.on('close', resolve);
     });
 
+    // Web ReadableStream(req.body) を busboy へ手動で流し込む。Readable.fromWeb().pipe()
+    // ではストリーム終端の伝播が不安定で busboy が "Unexpected end of form" を投げる
+    // ことがあるため、最後まで読み切ってから明示的に bb.end() する。
+    const pump = (async () => {
+        const reader = (req.body as ReadableStream<Uint8Array>).getReader();
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value && value.byteLength) {
+                    if (!bb.write(Buffer.from(value))) {
+                        await new Promise<void>((res) => bb.once('drain', res));
+                    }
+                }
+            }
+            bb.end();
+        } catch (err) {
+            bb.destroy(err as Error);
+            throw err;
+        }
+    })();
+
     bus.emitEvent({ type: 'stage', stage: 'upload-receive-start' });
-    nodeStream.pipe(bb);
 
     try {
-        await finished;
+        await Promise.all([finished, pump]);
         await Promise.all(saves);
         if (files.length === 0) {
             jobStore.set(jobId, { status: 'error', error: 'no files' });

--- a/src/app/api/pip/upload/route.ts
+++ b/src/app/api/pip/upload/route.ts
@@ -3,7 +3,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import Busboy from 'busboy';
-import { Readable } from 'node:stream';
 import { jobStore } from '@/lib/jobStore';
 import { ProgressBus, globalBusMap } from '@/lib/progressBus';
 import { uploadDistribution } from '@/lib/pip/publish';
@@ -38,7 +37,6 @@ export async function POST(req: NextRequest) {
     jobStore.set(jobId, { status: 'queued' });
 
     const bb = Busboy({ headers: { 'content-type': req.headers.get('content-type') || '' } });
-    const nodeStream = Readable.fromWeb(req.body as any);
     const tmpRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pip-upload-'));
     const files: Array<{ name: string; tmpPath: string; index: number }> = [];
     const saves: Promise<void>[] = [];
@@ -76,20 +74,43 @@ export async function POST(req: NextRequest) {
             ws.on('error', reject);
             fileStream.pipe(ws);
 
-            saves.push(new Promise<void>((res, rej) => {
+            const save = new Promise<void>((res, rej) => {
                 ws.on('finish', res);
                 ws.on('error', rej);
                 fileStream.on('error', rej);
-            }));
+            });
+            // 中断・切断時の未処理 rejection を防ぐ（正常系は Promise.all(saves) で検知）。
+            save.catch(() => {});
+            saves.push(save);
         });
         bb.on('error', reject);
-        bb.on('finish', resolve);
+        bb.on('close', resolve);
     });
 
-    nodeStream.pipe(bb);
+    // Web ReadableStream(req.body) を busboy へ手動で流し込む。Readable.fromWeb().pipe()
+    // ではストリーム終端の伝播が不安定で busboy が "Unexpected end of form" を投げる
+    // ことがあるため、最後まで読み切ってから明示的に bb.end() する。
+    const pump = (async () => {
+        const reader = (req.body as ReadableStream<Uint8Array>).getReader();
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value && value.byteLength) {
+                    if (!bb.write(Buffer.from(value))) {
+                        await new Promise<void>((res) => bb.once('drain', res));
+                    }
+                }
+            }
+            bb.end();
+        } catch (err) {
+            bb.destroy(err as Error);
+            throw err;
+        }
+    })();
 
     try {
-        await finished;
+        await Promise.all([finished, pump]);
         await Promise.all(saves);
 
         if (files.length === 0) {

--- a/src/app/api/rpm/upload/route.ts
+++ b/src/app/api/rpm/upload/route.ts
@@ -3,7 +3,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import Busboy from 'busboy';
-import { Readable } from 'node:stream';
 import { jobStore } from '@/lib/jobStore';
 import { ProgressBus, globalBusMap } from '@/lib/progressBus';
 import { uploadRpmFile, type RpmUploadMethod } from '@/lib/rpm/publish';
@@ -33,7 +32,6 @@ export async function POST(req: NextRequest) {
     jobStore.set(jobId, { status: 'queued' });
 
     const bb = Busboy({ headers: { 'content-type': req.headers.get('content-type') || '' } });
-    const nodeStream = Readable.fromWeb(req.body as any);
     const tmpRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rpm-upload-'));
     const files: Array<{ name: string; tmpPath: string; index: number }> = [];
     const saves: Promise<void>[] = [];
@@ -59,20 +57,43 @@ export async function POST(req: NextRequest) {
             fileStream.on('error', reject);
             ws.on('error', reject);
             fileStream.pipe(ws);
-            saves.push(new Promise<void>((res, rej) => {
+            const save = new Promise<void>((res, rej) => {
                 ws.on('finish', res);
                 ws.on('error', rej);
                 fileStream.on('error', rej);
-            }));
+            });
+            // 中断・切断時の未処理 rejection を防ぐ（正常系は Promise.all(saves) で検知）。
+            save.catch(() => {});
+            saves.push(save);
         });
         bb.on('error', reject);
-        bb.on('finish', resolve);
+        bb.on('close', resolve);
     });
 
-    nodeStream.pipe(bb);
+    // Web ReadableStream(req.body) を busboy へ手動で流し込む。Readable.fromWeb().pipe()
+    // ではストリーム終端の伝播が不安定で busboy が "Unexpected end of form" を投げる
+    // ことがあるため、最後まで読み切ってから明示的に bb.end() する。
+    const pump = (async () => {
+        const reader = (req.body as ReadableStream<Uint8Array>).getReader();
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value && value.byteLength) {
+                    if (!bb.write(Buffer.from(value))) {
+                        await new Promise<void>((res) => bb.once('drain', res));
+                    }
+                }
+            }
+            bb.end();
+        } catch (err) {
+            bb.destroy(err as Error);
+            throw err;
+        }
+    })();
 
     try {
-        await finished;
+        await Promise.all([finished, pump]);
         await Promise.all(saves);
 
         if (!files.length) {

--- a/src/app/docker/download.module.css
+++ b/src/app/docker/download.module.css
@@ -1,0 +1,324 @@
+/* Faithful reproduction of Carbon design — Docker download form (section 03) */
+
+.card {
+    background: var(--af-surface);
+    border: 1px solid var(--af-border);
+    border-radius: 16px;
+    overflow: hidden;
+}
+
+/* ---- auth section ---- */
+.authHeader {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 24px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-bottom: 1px solid var(--af-border);
+    cursor: pointer;
+    text-align: left;
+    color: var(--af-text);
+}
+.authHeaderTitle {
+    font-size: 14px;
+    font-weight: 600;
+}
+.authSub {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    color: var(--af-dim);
+    margin-top: 2px;
+}
+.chip {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    border-radius: 6px;
+    padding: 4px 9px;
+    line-height: 1;
+    flex: none;
+}
+.chipOk {
+    color: var(--af-success);
+    background: color-mix(in oklch, var(--af-success) 12%, transparent);
+}
+.chipMuted {
+    color: var(--af-dim);
+    background: var(--af-raised);
+}
+.chevron {
+    color: var(--af-dim);
+    display: inline-flex;
+    transition: transform 160ms ease;
+    flex: none;
+}
+.chevronOpen {
+    transform: rotate(180deg);
+}
+
+.authBody {
+    padding: 4px 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    background: var(--af-bg);
+    border-bottom: 1px solid var(--af-border);
+}
+
+/* ---- main inputs ---- */
+.mainBody {
+    padding: 26px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+.eyebrow {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--af-dim);
+}
+
+/* ---- fields ---- */
+.label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--af-muted);
+    margin-bottom: 7px;
+}
+.labelLg {
+    font-size: 13px;
+    color: var(--af-text);
+}
+.required {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    color: var(--af-docker);
+    background: color-mix(in oklch, var(--af-docker) 14%, transparent);
+    border-radius: 5px;
+    padding: 2px 7px;
+    line-height: 1;
+}
+
+.fieldBox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--af-raised);
+    border: 1px solid var(--af-border-strong);
+    border-radius: 10px;
+    padding: 0 12px;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.fieldBox:focus-within {
+    border-color: color-mix(in oklch, var(--af-docker) 55%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--af-docker) 12%, transparent);
+}
+.fieldIcon {
+    color: var(--af-dim);
+    display: inline-flex;
+    flex: none;
+}
+.input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--af-text);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 13px;
+    padding: 11px 0;
+}
+.input::placeholder {
+    color: var(--af-dim);
+}
+.inputLg {
+    font-size: 15px;
+    padding: 14px 0;
+}
+.iconBtn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--af-dim);
+    display: inline-flex;
+    padding: 0;
+}
+.iconBtn:hover {
+    color: var(--af-muted);
+}
+
+/* required (accent) field */
+.repoBox {
+    border-width: 1.5px;
+    border-color: color-mix(in oklch, var(--af-docker) 55%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--af-docker) 12%, transparent);
+}
+.repoBox .fieldIcon {
+    color: var(--af-docker);
+}
+.errorBox {
+    border-color: color-mix(in oklch, var(--af-error) 65%, transparent) !important;
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--af-error) 12%, transparent) !important;
+}
+.errorText {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11.5px;
+    color: var(--af-error);
+    margin-top: 6px;
+}
+
+.grid2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+}
+@media (max-width: 600px) {
+    .grid2 {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* segmented */
+.segmented {
+    display: flex;
+    background: var(--af-surface);
+    border: 1px solid var(--af-border-strong);
+    border-radius: 10px;
+    padding: 4px;
+    gap: 4px;
+}
+.segItem {
+    flex: 1;
+    text-align: center;
+    padding: 10px 0;
+    border-radius: 7px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--af-muted);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 12.5px;
+}
+.segItemActive {
+    background: var(--af-raised);
+    color: var(--af-text);
+}
+
+/* TLS toggle */
+.toggleRow {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    cursor: pointer;
+    user-select: none;
+}
+.toggle {
+    width: 38px;
+    height: 22px;
+    border-radius: 999px;
+    background: var(--af-raised);
+    border: 1px solid var(--af-border-strong);
+    position: relative;
+    flex: none;
+    transition: background 140ms ease, border-color 140ms ease;
+}
+.toggleOn {
+    background: var(--af-warning);
+    border-color: transparent;
+}
+.knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--af-dim);
+    transition: transform 140ms ease, background 140ms ease;
+}
+.knobOn {
+    transform: translateX(16px);
+    background: #0A0B0E;
+}
+.toggleLabel {
+    font-size: 13px;
+    color: var(--af-text);
+}
+.warnBadge {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    color: var(--af-warning);
+    background: color-mix(in oklch, var(--af-warning) 12%, transparent);
+    border-radius: 6px;
+    padding: 3px 8px;
+    line-height: 1;
+}
+
+/* footer */
+.footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    border-top: 1px solid var(--af-border);
+    background: var(--af-bg);
+    padding: 18px 24px;
+}
+.hint {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11.5px;
+    color: var(--af-dim);
+}
+.actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: none;
+}
+.btnGhost {
+    display: inline-flex;
+    align-items: center;
+    font-size: 13px;
+    color: var(--af-muted);
+    padding: 11px 16px;
+    border-radius: 10px;
+    border: 1px solid var(--af-border-strong);
+    background: none;
+    cursor: pointer;
+    text-decoration: none;
+}
+.btnGhost:hover {
+    color: var(--af-text);
+    background: var(--af-raised);
+}
+.btnPrimary {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: #070A10;
+    padding: 12px 20px;
+    border-radius: 10px;
+    background: var(--af-docker);
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 0 22px color-mix(in oklch, var(--af-docker) 40%, transparent);
+    transition: filter 120ms ease;
+}
+.btnPrimary:hover {
+    filter: brightness(1.08);
+}
+.btnPrimary:disabled {
+    opacity: 0.6;
+    cursor: default;
+    box-shadow: none;
+}

--- a/src/app/docker/download.tsx
+++ b/src/app/docker/download.tsx
@@ -1,13 +1,24 @@
 'use client';
-import { Accordion, Alert, Button, Checkbox, PasswordInput, Stack, Text, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
 import { useRef, useState, useEffect, useCallback } from "react";
-import { IconAlertTriangle, IconArrowRight, IconCloudCog } from "@tabler/icons-react";
+import {
+    IconAlertCircle,
+    IconArrowRight,
+    IconChevronDown,
+    IconCube,
+    IconEye,
+    IconEyeOff,
+    IconKey,
+    IconLock,
+    IconWorld,
+} from "@tabler/icons-react";
 import { Layer } from "@/lib/progressBus";
 import { ProgressEvent } from "@/lib/progressBus";
 import { DownloadModal } from "@/components/Download/Modal";
-import { FormCard } from "@/components/FormCard";
+import classes from "./download.module.css";
+
+const PLATFORMS = ["linux/amd64", "linux/arm64"];
 
 type FormType = {
     registry: string;
@@ -23,7 +34,9 @@ export function DownloadPane() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<null|string>(null);
     const [opened, {open, close}] = useDisclosure(false);
-    
+    const [authOpen, setAuthOpen] = useState(true);
+    const [showPassword, setShowPassword] = useState(false);
+
     const [jobId, setJobId] = useState<string|null>(null);
     const [status, setStatus] = useState<string>("idle");
     const [layers, setLayers] = useState<Layer[]>([]);
@@ -56,7 +69,7 @@ export function DownloadPane() {
     }, [])
     
     const form = useForm<FormType>({
-        mode: "uncontrolled",
+        mode: "controlled",
         initialValues: {
             registry: "",
             repo: "",
@@ -148,128 +161,184 @@ export function DownloadPane() {
         };
     }, []);
     
+    const values = form.getValues();
+    const registryLabel = values.registry?.trim() || "registry-1.docker.io";
+    const authConfigured = Boolean(values.username && values.password);
+    const authSub = `${registryLabel} · ${values.username ? "認証あり" : "認証なし"} · TLS 検証 ${values.insecureTLS ? "OFF" : "ON"}`;
+    const repoError = form.errors.repo as string | undefined;
+
     return (
         <div>
-            <Alert
-                variant="light"
-                color="warning"
-                icon={<IconAlertTriangle size="1.1em" />}
-                radius="md"
-                mb="lg"
-            >
-                大きなイメージの場合、ダウンロードまでに時間がかかる可能性があります。
-            </Alert>
+            <form onSubmit={form.onSubmit(onSubmit)}>
+                <div className={classes.card}>
 
-            <form
-                onSubmit={form.onSubmit(onSubmit)}
-            >
-                <FormCard
-                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存を解決して tar 化します</Text>}
-                    actions={
-                        <Button
-                            size="md"
-                            radius="md"
-                            color="docker"
-                            type="submit"
-                            loading={loading}
-                            rightSection={<IconArrowRight size="1.05rem" />}
+                    {/* ---- 接続 / 認証設定 ---- */}
+                    <div>
+                        <button
+                            type="button"
+                            className={classes.authHeader}
+                            onClick={() => setAuthOpen((o) => !o)}
+                            aria-expanded={authOpen}
                         >
-                            取得を開始
-                        </Button>
-                    }
-                >
-                <Stack>
-                    <Accordion
-                        variant="separated"
-                        radius="md"
-                    >
-                        <Accordion.Item value="registry_settings" key="registry_settings">
-                            <Accordion.Control icon={<IconCloudCog size="1em"/>}>
-                                接続 / 認証設定（任意・Docker Hub 以外）
-                            </Accordion.Control>
-                            <Accordion.Panel>
-                                <Stack>
-                                    <TextInput
-                                        label="Registry"
-                                        description="空欄なら Docker Hub。例: ghcr.io, quay.io, registry.example.com:5000"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="ghcr.io"
-                                        key={form.key("registry")}
-                                        {...form.getInputProps("registry")}
+                            <span className={classes.fieldIcon}><IconLock size={18} stroke={1.7} /></span>
+                            <div style={{ flex: 1, minWidth: 0 }}>
+                                <div className={classes.authHeaderTitle}>接続 / 認証設定</div>
+                                <div className={classes.authSub}>{authSub}</div>
+                            </div>
+                            <span className={`${classes.chip} ${authConfigured ? classes.chipOk : classes.chipMuted}`}>
+                                {authConfigured ? "設定済" : "任意"}
+                            </span>
+                            <span className={`${classes.chevron} ${authOpen ? classes.chevronOpen : ""}`}>
+                                <IconChevronDown size={18} stroke={1.7} />
+                            </span>
+                        </button>
+
+                        {authOpen && (
+                            <div className={classes.authBody}>
+                                <div>
+                                    <label className={classes.label}>レジストリ URL</label>
+                                    <div className={classes.fieldBox}>
+                                        <span className={classes.fieldIcon}><IconWorld size={16} stroke={1.6} /></span>
+                                        <input
+                                            className={classes.input}
+                                            placeholder="registry-1.docker.io"
+                                            value={values.registry}
+                                            onChange={(e) => form.setFieldValue("registry", e.currentTarget.value)}
+                                            disabled={loading}
+                                        />
+                                    </div>
+                                </div>
+                                <div className={classes.grid2}>
+                                    <div>
+                                        <label className={classes.label}>ユーザー名</label>
+                                        <div className={classes.fieldBox}>
+                                            <input
+                                                className={classes.input}
+                                                placeholder="username"
+                                                value={values.username}
+                                                onChange={(e) => form.setFieldValue("username", e.currentTarget.value)}
+                                                disabled={loading}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <label className={classes.label}>パスワード / トークン</label>
+                                        <div className={classes.fieldBox}>
+                                            <span className={classes.fieldIcon}><IconKey size={16} stroke={1.6} /></span>
+                                            <input
+                                                className={classes.input}
+                                                type={showPassword ? "text" : "password"}
+                                                placeholder="password / token"
+                                                value={values.password}
+                                                onChange={(e) => form.setFieldValue("password", e.currentTarget.value)}
+                                                disabled={loading}
+                                            />
+                                            <button
+                                                type="button"
+                                                className={classes.iconBtn}
+                                                onClick={() => setShowPassword((s) => !s)}
+                                                aria-label={showPassword ? "隠す" : "表示"}
+                                            >
+                                                {showPassword ? <IconEyeOff size={16} stroke={1.6} /> : <IconEye size={16} stroke={1.6} />}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div
+                                    className={classes.toggleRow}
+                                    role="switch"
+                                    aria-checked={values.insecureTLS}
+                                    tabIndex={0}
+                                    onClick={() => form.setFieldValue("insecureTLS", !values.insecureTLS)}
+                                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); form.setFieldValue("insecureTLS", !values.insecureTLS); } }}
+                                >
+                                    <span className={`${classes.toggle} ${values.insecureTLS ? classes.toggleOn : ""}`}>
+                                        <span className={`${classes.knob} ${values.insecureTLS ? classes.knobOn : ""}`} />
+                                    </span>
+                                    <span className={classes.toggleLabel}>TLS 証明書の検証をスキップ</span>
+                                    <span className={classes.warnBadge}>注意</span>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* ---- 取得対象 ---- */}
+                    <div className={classes.mainBody}>
+                        <div className={classes.eyebrow}>取得対象</div>
+                        <div>
+                            <label className={`${classes.label} ${classes.labelLg}`}>
+                                リポジトリ <span className={classes.required}>必須</span>
+                            </label>
+                            <div className={`${classes.fieldBox} ${classes.repoBox} ${repoError ? classes.errorBox : ""}`}>
+                                <span className={classes.fieldIcon}><IconCube size={18} stroke={1.7} /></span>
+                                <input
+                                    className={`${classes.input} ${classes.inputLg}`}
+                                    placeholder="library/nginx"
+                                    value={values.repo}
+                                    onChange={(e) => form.setFieldValue("repo", e.currentTarget.value)}
+                                    disabled={loading}
+                                />
+                            </div>
+                            {repoError && (
+                                <div className={classes.errorText}>
+                                    <IconAlertCircle size={13} stroke={2} />{repoError}
+                                </div>
+                            )}
+                        </div>
+                        <div className={classes.grid2}>
+                            <div>
+                                <label className={`${classes.label} ${classes.labelLg}`}>タグ</label>
+                                <div className={classes.fieldBox}>
+                                    <input
+                                        className={`${classes.input} ${classes.inputLg}`}
+                                        placeholder="1.27-alpine"
+                                        value={values.tag}
+                                        onChange={(e) => form.setFieldValue("tag", e.currentTarget.value)}
                                         disabled={loading}
                                     />
-                                    <TextInput
-                                        label="Username"
-                                        description="プライベートイメージの場合に入力（任意）"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="username"
-                                        key={form.key("username")}
-                                        {...form.getInputProps("username")}
-                                        disabled={loading}
-                                    />
-                                    <PasswordInput
-                                        label="Password / Token"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="password または access token"
-                                        key={form.key("password")}
-                                        {...form.getInputProps("password")}
-                                        disabled={loading}
-                                    />
-                                    <Checkbox
-                                        label="TLS証明書の検証をスキップする"
-                                        description="自己署名証明書の社内レジストリ向け"
-                                        key={form.key("insecureTLS")}
-                                        {...form.getInputProps("insecureTLS", { type: "checkbox" })}
-                                        disabled={loading}
-                                    />
-                                </Stack>
-                            </Accordion.Panel>
-                        </Accordion.Item>
-                    </Accordion>
-                    <TextInput
-                        label="Repository"
-                        description="欲しいDockerイメージ名を入力（Registry欄を空にして ghcr.io/owner/name 形式でも可）"
-                        size="lg"
-                        radius="lg"
-                        placeholder="library/redis"
-                        key={form.key("repo")}
-                        {...form.getInputProps("repo")}
-                        disabled={loading}
-                    />
-                    <TextInput
-                        label="Tag"
-                        size="lg"
-                        radius="lg"
-                        placeholder="7.2"
-                        key={form.key("tag")}
-                        {...form.getInputProps("tag")}
-                        disabled={loading}
-                    />
-                    <TextInput
-                        label="Platform"
-                        size="lg"
-                        radius="lg"
-                        placeholder="linux/amd64"
-                        key={form.key("platform")}
-                        {...form.getInputProps("platform")}
-                        disabled={loading}
-                    />
-                </Stack>
-                </FormCard>
+                                </div>
+                            </div>
+                            <div>
+                                <label className={`${classes.label} ${classes.labelLg}`}>プラットフォーム</label>
+                                <div className={classes.segmented}>
+                                    {PLATFORMS.map((p) => (
+                                        <button
+                                            key={p}
+                                            type="button"
+                                            className={`${classes.segItem} ${values.platform === p ? classes.segItemActive : ""}`}
+                                            onClick={() => form.setFieldValue("platform", p)}
+                                            disabled={loading}
+                                        >
+                                            {p}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* ---- action footer ---- */}
+                    <div className={classes.footer}>
+                        <span className={classes.hint}>依存を解決して tar 化します</span>
+                        <div className={classes.actions}>
+                            {jobId && (
+                                <button type="button" className={classes.btnGhost} onClick={open}>進捗を表示</button>
+                            )}
+                            <button type="submit" className={classes.btnPrimary} disabled={loading}>
+                                取得を開始
+                                <IconArrowRight size={17} stroke={2} />
+                            </button>
+                        </div>
+                    </div>
+
+                </div>
             </form>
-        
-            {error && <Alert
-                color="red"
-                radius="lg"
-                title="エラー"
-                my="lg"
-                variant="light"
-            >
-                {error}
-            </Alert>}
+
+            {error && (
+                <div className={classes.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
+            )}
 
             <DownloadModal
                 opened={opened}

--- a/src/app/docker/download.tsx
+++ b/src/app/docker/download.tsx
@@ -1,12 +1,13 @@
 'use client';
-import { Accordion, Alert, Button, Checkbox, PasswordInput, Space, Stack, TextInput } from "@mantine/core";
+import { Accordion, Alert, Button, Checkbox, PasswordInput, Stack, Text, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
 import { useRef, useState, useEffect, useCallback } from "react";
-import { IconCloudCog } from "@tabler/icons-react";
+import { IconAlertTriangle, IconArrowRight, IconCloudCog } from "@tabler/icons-react";
 import { Layer } from "@/lib/progressBus";
 import { ProgressEvent } from "@/lib/progressBus";
 import { DownloadModal } from "@/components/Download/Modal";
+import { FormCard } from "@/components/FormCard";
 
 type FormType = {
     registry: string;
@@ -151,25 +152,40 @@ export function DownloadPane() {
         <div>
             <Alert
                 variant="light"
-                color="yellow"
-                title="注意"
-                radius="lg"
-                my="xl"
+                color="warning"
+                icon={<IconAlertTriangle size="1.1em" />}
+                radius="md"
+                mb="lg"
             >
-                大きなイメージの場合、ダウンロードまでに時間がかかる可能性があります!
+                大きなイメージの場合、ダウンロードまでに時間がかかる可能性があります。
             </Alert>
 
             <form
                 onSubmit={form.onSubmit(onSubmit)}
             >
+                <FormCard
+                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存を解決して tar 化します</Text>}
+                    actions={
+                        <Button
+                            size="md"
+                            radius="md"
+                            color="docker"
+                            type="submit"
+                            loading={loading}
+                            rightSection={<IconArrowRight size="1.05rem" />}
+                        >
+                            取得を開始
+                        </Button>
+                    }
+                >
                 <Stack>
                     <Accordion
                         variant="separated"
-                        radius="lg"
+                        radius="md"
                     >
                         <Accordion.Item value="registry_settings" key="registry_settings">
                             <Accordion.Control icon={<IconCloudCog size="1em"/>}>
-                                レジストリ設定（任意・Docker Hub 以外）
+                                接続 / 認証設定（任意・Docker Hub 以外）
                             </Accordion.Control>
                             <Accordion.Panel>
                                 <Stack>
@@ -241,16 +257,8 @@ export function DownloadPane() {
                         {...form.getInputProps("platform")}
                         disabled={loading}
                     />
-                    <Space h="md" />
-                    <Button
-                        size="lg"
-                        radius="lg"
-                        type="submit"
-                        loading={loading}
-                    >
-                        Build & Download
-                    </Button>
                 </Stack>
+                </FormCard>
             </form>
         
             {error && <Alert

--- a/src/app/docker/page.tsx
+++ b/src/app/docker/page.tsx
@@ -59,12 +59,14 @@ export default function Docker() {
                 </Tabs.List>
                 <Tabs.Panel
                     value="download"
+                    py="lg"
                 >
                     <DownloadPane />
                 </Tabs.Panel>
                 {/^(1|true|on|yes)$/i.test(env.DOCKER_UPLOAD || '') && (
                     <Tabs.Panel
                         value="upload"
+                        py="lg"
                     >
                         <UploadPane />
                     </Tabs.Panel>

--- a/src/app/docker/page.tsx
+++ b/src/app/docker/page.tsx
@@ -1,9 +1,10 @@
 'use client';
-import { Group, Space, Tabs, Text, ThemeIcon, Title } from "@mantine/core";
-import { IconBrandDocker, IconDownload, IconUpload } from "@tabler/icons-react";
+import { Space, Tabs } from "@mantine/core";
+import { IconDownload, IconUpload } from "@tabler/icons-react";
 import { DownloadPane } from "./download";
 import { UploadPane } from "./upload";
 import { getEnvironmentVar } from "@/components/actions";
+import { PageHeader } from "@/components/PageHeader";
 import { useEffect, useState } from "react";
 
 type EnvType = {
@@ -28,33 +29,17 @@ export default function Docker() {
 
     return (
         <div>
-            <Group
-                justify="space-between"
-            >
-                <Title>
-                    Docker Image
-                </Title>
-                <ThemeIcon
-                    variant="transparent"
-                    size={60}
-                >
-                    <IconBrandDocker
-                        style={{width: '70%', height: '70%'}}
-                        stroke={1.3}
-                    />
-                </ThemeIcon>
-            </Group>
-            <Text
-                c="dimmed"
-            >
-                Docker HubのリポジトリからAPIを使用してイメージをダウンロードし、ロードできる形で固めたものをダウンロードします
-            </Text>
+            <PageHeader
+                manager="docker"
+                description="レジストリからイメージを依存ごと取得し、docker load 可能な tar を生成。push にも対応。"
+            />
 
-            <Space h="xl" />
+            <Space h="md" />
 
             <Tabs
                 variant="pills"
-                radius="lg"
+                color="docker"
+                radius="xl"
                 defaultValue="download"
             >
                 <Tabs.List>

--- a/src/app/docker/upload.tsx
+++ b/src/app/docker/upload.tsx
@@ -1,9 +1,9 @@
 'use client';
-import { Accordion, Alert, Button, Checkbox, Group, PasswordInput, Space, Stack, Text, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure, useMap } from "@mantine/hooks";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from "@tabler/icons-react";
+import { IconAlertCircle, IconCloudUpload, IconCube, IconKey, IconRefresh, IconServer, IconX } from "@tabler/icons-react";
+import { CarbonForm, CarbonSection, CarbonField, CarbonPassword, CarbonCheckbox, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonGhostButton, CarbonList, carbonClasses, carbonDropzoneClasses } from "@/components/CarbonForm";
 import { Layer } from "@/lib/progressBus";
 import { ProgressEvent } from "@/lib/progressBus";
 import { Dropzone } from "@mantine/dropzone";
@@ -286,7 +286,7 @@ export function UploadPane() {
         indexMapRef.current = new Map();
     };
     const form = useForm<FormType>({
-        mode: "uncontrolled",
+        mode: "controlled",
         initialValues: {
             files: [],
             useManifest: true,
@@ -436,203 +436,107 @@ export function UploadPane() {
 
     const failedCount = Object.values(perFileSnap).filter((state) => state?.status === 'error').length;
 
+    const dockerFiles = form.getValues().files;
+    const dockerCompleted = Object.values(perFileSnap).filter((s) => s?.status === "done" || s?.status === "published").length;
+    const useManifest = form.getValues().useManifest || dockerFiles.length > 1;
+
     return (
         <div>
-            <Alert
-                variant="light"
-                color="warning"
-                icon={<IconAlertTriangle size="1.1em" />}
-                radius="md"
-                mb="lg"
-            >
-                大きなイメージの場合、アップロードに時間がかかる場合があります。
-            </Alert>
+            <CarbonForm accent="docker" onSubmit={onSubmit}>
+                <CarbonAuthPanel
+                    icon={IconServer}
+                    title="アップロード先"
+                    sub={`${form.getValues().registry?.trim() || 'レジストリ未設定'} · ${form.getValues().username ? '認証あり' : '認証なし'}`}
+                    configured={Boolean(form.getValues().registry?.trim())}
+                    defaultOpen
+                >
+                    <CarbonField label="Registry" icon={IconServer} value={form.getValues().registry} onChange={(v) => form.setFieldValue('registry', v)} placeholder="https://docker-hub-clone.example.com" disabled={loading} />
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                        <CarbonField label="Username" optional small value={form.getValues().username} onChange={(v) => form.setFieldValue('username', v)} placeholder="username" disabled={loading} />
+                        <CarbonPassword label="Password" optional icon={IconKey} value={form.getValues().password} onChange={(v) => form.setFieldValue('password', v)} placeholder="password" disabled={loading} />
+                    </div>
+                </CarbonAuthPanel>
 
-            <form
-                onSubmit={onSubmit}
-            >
-                <Stack>
-                    <Accordion
-                        variant="separated"
-                        radius="lg"
-                    >
-                        <Accordion.Item
-                            value="upload_settings"
-                            key="upload_settings"
-                        >
-                            <Accordion.Control
-                                icon={<IconCloudCog size="1em"/>}
-                            >
-                                アップロード先設定
-                            </Accordion.Control>
-                            <Accordion.Panel>
-                                <Stack>
-                                    <TextInput
-                                        label="Registry"
-                                        description="アップロード先のレジストリを入力"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="https://docker-hub-clone.example.com"
-                                        key={form.key("registry")}
-                                        {...form.getInputProps("registry")}
-                                        disabled={loading}
-                                    />
-                                    <TextInput
-                                        label="Username"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="username"
-                                        key={form.key("username")}
-                                        {...form.getInputProps("username")}
-                                        disabled={loading}
-                                    />
-                                    <PasswordInput
-                                        label="Password"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="password"
-                                        key={form.key("password")}
-                                        {...form.getInputProps("password")}
-                                        disabled={loading}
-                                    />
-                                </Stack>
-                            </Accordion.Panel>
-                        </Accordion.Item>
-                    </Accordion>
+                <CarbonSection>
                     <Dropzone
-                        onDrop={(files) => {
+                        onDrop={(dropped) => {
                             if (loading) return;
-                            form.setFieldValue('files', files);
+                            form.setFieldValue('files', dropped);
                             perFileRef.current = Object.fromEntries(
-                                files.map((file, idx) => [idx, { received: 0, total: file.size, status: 'waiting' }])
+                                dropped.map((file, idx) => [idx, { received: 0, total: file.size, status: 'waiting' }])
                             ) as Record<number, { received: number; total?: number; status: string }>;
                             setPerFileSnap({ ...perFileRef.current });
                         }}
-                        radius="lg"
                         accept={["application/x-tar"]}
                         p="xl"
+                        className={carbonDropzoneClasses.root}
                     >
-                        <div
-                            style={{pointerEvents: "none"}}
-                        >
-                            <Group justify="center">
-                                <Dropzone.Accept>
-                                    <IconDownload size={50} color={"blue.6"} stroke={1.5} />
-                                </Dropzone.Accept>
-                                <Dropzone.Reject>
-                                    <IconX size={50} color={"red.6"} stroke={1.5} />
-                                </Dropzone.Reject>
-                                <Dropzone.Idle>
-                                    <IconCloudUpload size={50} stroke={1.5}/>
-                                </Dropzone.Idle>
-                            </Group>
-
-                            <Text ta="center" fw={700} fz="lg" mt="xl">
-                                <Dropzone.Accept>ここにファイルをドロップ</Dropzone.Accept>
-                                <Dropzone.Idle>Dockerイメージをアップロード</Dropzone.Idle>
-                            </Text>
-
-                            <Text ta="center" c="dimmed">
-                                .tar形式で固められたDockerイメージをドロップすることでアップロードします
-                            </Text>
+                        <div style={{ pointerEvents: "none", textAlign: "center" }}>
+                            <span className={carbonDropzoneClasses.icon}>
+                                <Dropzone.Idle><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Idle>
+                                <Dropzone.Accept><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Accept>
+                                <Dropzone.Reject><IconX size={26} stroke={1.7} /></Dropzone.Reject>
+                            </span>
+                            <div className={carbonDropzoneClasses.title}>
+                                <Dropzone.Idle>Docker イメージ tar をドロップ</Dropzone.Idle>
+                                <Dropzone.Accept>ここにドロップ</Dropzone.Accept>
+                                <Dropzone.Reject>対応していないファイルです</Dropzone.Reject>
+                            </div>
+                            <div className={carbonDropzoneClasses.sub}>docker save で出力した .tar ・ 複数可</div>
                         </div>
                     </Dropzone>
-                    <Stack>
-                        <Text
-                            size="sm"
-                            fw="bold"
-                        >
-                            選択済みファイル({form.getValues().files.length})
-                        </Text>
-                        {form.getValues().files.map((file, i) => (
-                            <FileItem
-                                key={i}
-                                file={file}
-                                percent={perFileSnap[i]?.status == "done" ? 100 : Math.floor(((perFileSnap[i]?.received ?? 0) / file.size) * 100)}
-                                status={perFileSnap[i]?.status}
-                                onDelete={() => {
-                                    if (loading) return;
-                                    const currentFiles = form.getValues().files;
-                                    const nextFiles = currentFiles.filter((_, idx) => idx !== i);
-                                    form.setFieldValue('files', nextFiles);
-                                    perFileRef.current = Object.fromEntries(
-                                        nextFiles.map((nextFile, index) => [index, { received: 0, total: nextFile.size, status: 'waiting' }])
-                                    ) as Record<number, { received: number; total?: number; status: string }>;
-                                    setPerFileSnap({ ...perFileRef.current });
-                                }}
-                            />
-                        ))}
-                    </Stack>
-                    <Space h="lg" />
-                    <Checkbox
-                        label="manifestの情報を使用する"
-                        description="イメージ名とタグをmanifestの情報から自動的に決定します"
-                        size="md"
-                        radius="md"
-                        checked={form.getValues().useManifest || form.getValues().files.length > 1}
-                        disabled={form.getValues().files.length > 1}
-                        onChange={e=>form.setFieldValue('useManifest', e.currentTarget.checked)}
-                    />
-                    {!form.getValues().useManifest && (
-                        <>
-                            <TextInput
-                                label="Repository"
-                                description="アップロードするDockerイメージのリポジトリ名"
-                                size="lg"
-                                radius="lg"
-                                placeholder="library/redis"
-                                key={form.key("repo")}
-                                {...form.getInputProps("repo")}
-                                disabled={loading}
-                            />
-                            <TextInput
-                                label="Tag"
-                                size="lg"
-                                radius="lg"
-                                placeholder="7.2"
-                                key={form.key("tag")}
-                                {...form.getInputProps("tag")}
-                                disabled={loading}
-                            />
-                        </>
+
+                    {dockerFiles.length > 0 && (
+                        <CarbonList title={`キュー · ${dockerFiles.length} ファイル`} right={`${dockerCompleted} / ${dockerFiles.length} 完了`}>
+                            {dockerFiles.map((file, i) => (
+                                <FileItem
+                                    key={i}
+                                    file={file}
+                                    percent={perFileSnap[i]?.status == "done" ? 100 : Math.floor(((perFileSnap[i]?.received ?? 0) / file.size) * 100)}
+                                    status={perFileSnap[i]?.status}
+                                    onDelete={() => {
+                                        if (loading) return;
+                                        const currentFiles = form.getValues().files;
+                                        const nextFiles = currentFiles.filter((_, idx) => idx !== i);
+                                        form.setFieldValue('files', nextFiles);
+                                        perFileRef.current = Object.fromEntries(
+                                            nextFiles.map((nextFile, index) => [index, { received: 0, total: nextFile.size, status: 'waiting' }])
+                                        ) as Record<number, { received: number; total?: number; status: string }>;
+                                        setPerFileSnap({ ...perFileRef.current });
+                                    }}
+                                />
+                            ))}
+                        </CarbonList>
                     )}
 
-                    <Space h="md" />
-                    <Button
-                        size="md"
-                        radius="md"
-                        color="docker"
-                        type="submit"
-                        loading={loading}
-                        leftSection={<IconCloudUpload size="1.1rem" />}
-                    >
-                        アップロード実行
-                    </Button>
-                    <Button
-                        type="button"
-                        size="md"
-                        radius="md"
-                        variant="light"
-                        color="docker"
-                        leftSection={<IconRefresh size="1.1rem" />}
-                        onClick={handleRetryFailed}
-                        disabled={loading || failedCount === 0}
-                    >
-                        失敗したイメージを再試行
-                    </Button>
-                </Stack>
-            </form>
+                    <CarbonCheckbox
+                        checked={useManifest}
+                        onChange={(c) => form.setFieldValue('useManifest', c)}
+                        label="manifest の情報を使用する（イメージ名・タグを自動決定）"
+                        disabled={dockerFiles.length > 1}
+                    />
+                    {!useManifest && (
+                        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                            <CarbonField label="Repository" icon={IconCube} value={form.getValues().repo} onChange={(v) => form.setFieldValue('repo', v)} placeholder="library/redis" disabled={loading} />
+                            <CarbonField label="Tag" value={form.getValues().tag} onChange={(v) => form.setFieldValue('tag', v)} placeholder="7.2" disabled={loading} />
+                        </div>
+                    )}
+                </CarbonSection>
 
-            {error && <Alert
-                color="npm"
-                radius="md"
-                title="エラー"
-                my="lg"
-                variant="light"
-            >
-                {error}
-            </Alert>}
-            
+                <CarbonFooter hint={dockerFiles.length ? `${dockerFiles.length} イメージを push します` : '.tar を追加してください'}>
+                    {failedCount > 0 && !loading && (
+                        <CarbonGhostButton onClick={handleRetryFailed}><IconRefresh size={15} /> 失敗を再試行</CarbonGhostButton>
+                    )}
+                    <CarbonSubmit loading={loading} icon={IconCloudUpload}>アップロード実行</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
+
+            {error && (
+                <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
+            )}
+
             <UploadModal
                 opened={opened}
                 onClose={()=>{

--- a/src/app/docker/upload.tsx
+++ b/src/app/docker/upload.tsx
@@ -3,7 +3,7 @@ import { Accordion, Alert, Button, Checkbox, Group, PasswordInput, Space, Stack,
 import { useForm } from "@mantine/form";
 import { useDisclosure, useMap } from "@mantine/hooks";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from "@tabler/icons-react";
+import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from "@tabler/icons-react";
 import { Layer } from "@/lib/progressBus";
 import { ProgressEvent } from "@/lib/progressBus";
 import { Dropzone } from "@mantine/dropzone";
@@ -440,12 +440,12 @@ export function UploadPane() {
         <div>
             <Alert
                 variant="light"
-                color="yellow"
-                title="注意"
-                radius="lg"
-                my="xl"
+                color="warning"
+                icon={<IconAlertTriangle size="1.1em" />}
+                radius="md"
+                mb="lg"
             >
-                大きなイメージの場合、アップロードに時間がかかる場合があります!
+                大きなイメージの場合、アップロードに時間がかかる場合があります。
             </Alert>
 
             <form
@@ -599,18 +599,21 @@ export function UploadPane() {
 
                     <Space h="md" />
                     <Button
-                        size="lg"
-                        radius="lg"
+                        size="md"
+                        radius="md"
+                        color="docker"
                         type="submit"
                         loading={loading}
+                        leftSection={<IconCloudUpload size="1.1rem" />}
                     >
-                        Upload & Push
+                        アップロード実行
                     </Button>
                     <Button
                         type="button"
-                        size="lg"
-                        radius="lg"
+                        size="md"
+                        radius="md"
                         variant="light"
+                        color="docker"
                         leftSection={<IconRefresh size="1.1rem" />}
                         onClick={handleRetryFailed}
                         disabled={loading || failedCount === 0}
@@ -619,10 +622,10 @@ export function UploadPane() {
                     </Button>
                 </Stack>
             </form>
-        
+
             {error && <Alert
-                color="red"
-                radius="lg"
+                color="npm"
+                radius="md"
                 title="エラー"
                 my="lg"
                 variant="light"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,98 @@
+/* ============================================================
+   Carbon design system — global tokens & polish
+   ============================================================ */
+
+:root {
+    /* Artifact accents (oklch, hue のみ変化) */
+    --af-docker: oklch(0.66 0.16 250);
+    --af-npm: oklch(0.62 0.20 25);
+    --af-pip: oklch(0.64 0.18 300);
+    --af-rpm: oklch(0.82 0.14 90);
+    --af-hf: oklch(0.72 0.13 188);
+
+    /* Status */
+    --af-success: oklch(0.74 0.15 150);
+    --af-running: oklch(0.66 0.16 250);
+    --af-warning: oklch(0.80 0.14 80);
+    --af-error: oklch(0.62 0.20 25);
+    --af-skipped: #7B8390;
+
+    /* Radius scale */
+    --af-radius-sm: 9px;
+    --af-radius-md: 14px;
+    --af-radius-lg: 18px;
+}
+
+/* Surfaces — dark (default) */
+:root[data-mantine-color-scheme="dark"] {
+    --af-bg: #0A0B0E;
+    --af-surface: #14161B;
+    --af-raised: #1C1F26;
+    --af-border: rgba(255, 255, 255, 0.07);
+    --af-border-strong: rgba(255, 255, 255, 0.12);
+    --af-text: #F2F4F8;
+    --af-muted: #9AA1AE;
+    --af-dim: #6B7280;
+
+    --mantine-color-body: #0A0B0E;
+}
+
+/* Surfaces — light (warm) */
+:root[data-mantine-color-scheme="light"] {
+    --af-bg: #FBFAF8;
+    --af-surface: #FFFFFF;
+    --af-raised: #F2F0EC;
+    --af-border: #E8E6E2;
+    --af-border-strong: #D8D5CF;
+    --af-text: #1B1C20;
+    --af-muted: #6A6E78;
+    --af-dim: #9C9890;
+
+    --mantine-color-body: #FBFAF8;
+}
+
+body {
+    background: var(--af-bg);
+    color: var(--af-text);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+}
+
+/* Monospace meta helper */
+.af-mono {
+    font-family: var(--mantine-font-family-monospace);
+    font-variant-ligatures: none;
+}
+
+/* Section eyebrow label */
+.af-eyebrow {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--af-dim);
+}
+
+/* Subtle scrollbars */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: var(--af-raised) transparent;
+}
+*::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+    background: var(--af-raised);
+    border-radius: 999px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+    background: var(--af-border-strong);
+    background-clip: padding-box;
+}
+
+::selection {
+    background: oklch(0.66 0.16 250 / 0.35);
+}

--- a/src/app/hf/download.tsx
+++ b/src/app/hf/download.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { ProgressEvent } from '@/lib/progressBus';
-import { Alert, Button, Group, PasswordInput, Space, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import { Button, Space, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconArrowRight, IconDownload, IconInfoCircle } from '@tabler/icons-react';
+import { IconBrain, IconDownload, IconInfoCircle, IconKey } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FormCard } from '@/components/FormCard';
 import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
+import { CarbonForm, CarbonSection, CarbonField, CarbonTextarea, CarbonPassword, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonGhostButton } from '@/components/CarbonForm';
 
 type Status = 'idle' | 'starting' | 'running' | 'done' | 'error';
 
@@ -42,6 +42,7 @@ export function DownloadPane() {
     const esRef = useRef<EventSource | null>(null);
 
     const form = useForm<FormValues>({
+        mode: 'controlled',
         initialValues: {
             repoId: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
             revision: 'main',
@@ -241,31 +242,60 @@ export function DownloadPane() {
     });
     const doneCount = items.filter((i) => i.status === 'done').length;
 
+    const v = form.getValues();
     return (
         <>
-            <form onSubmit={submit}>
-                <FormCard
-                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">必要ファイルを選択取得して tar 化します</Text>}
-                    actions={<Button type="submit" loading={loading} size="md" radius="md" color="hf" rightSection={<IconArrowRight size="1.05rem" />}>取得を開始</Button>}
+            <CarbonForm accent="hf" onSubmit={submit}>
+                <CarbonAuthPanel
+                    icon={IconKey}
+                    title="認証設定"
+                    sub={`Hugging Face Token · ${v.token ? '設定済' : 'gated model のみ必要'}`}
+                    configured={Boolean(v.token)}
+                    defaultOpen={false}
                 >
-                <Stack>
-                    <TextInput label="Model Repo ID" placeholder="Qwen/Qwen2.5-0.5B-Instruct-GGUF" required {...form.getInputProps('repoId')} />
-                    <Group grow>
-                        <TextInput label="Revision" placeholder="main" {...form.getInputProps('revision')} />
-                        <TextInput label="Bundle name (optional)" placeholder="qwen2.5-local" {...form.getInputProps('bundleName')} />
-                    </Group>
-                    <Textarea label="Include patterns (1行1パターン)" minRows={4} autosize {...form.getInputProps('includePatterns')} />
-                    <Textarea label="Exclude patterns (1行1パターン)" minRows={2} autosize {...form.getInputProps('excludePatterns')} />
-                    <PasswordInput label="Hugging Face Token (gated modelのみ必要)" placeholder="hf_xxx" {...form.getInputProps('token')} />
+                    <CarbonPassword
+                        label="Hugging Face Token"
+                        optional
+                        icon={IconKey}
+                        value={v.token}
+                        onChange={(val) => form.setFieldValue('token', val)}
+                        placeholder="hf_xxx"
+                        disabled={loading}
+                    />
+                </CarbonAuthPanel>
+
+                <CarbonSection label="取得対象">
+                    <CarbonField
+                        label="Model Repo ID"
+                        required
+                        accent
+                        icon={IconBrain}
+                        value={v.repoId}
+                        onChange={(val) => form.setFieldValue('repoId', val)}
+                        placeholder="Qwen/Qwen2.5-0.5B-Instruct-GGUF"
+                        disabled={loading}
+                        error={form.errors.repoId as string | undefined}
+                    />
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                        <CarbonField label="Revision" small value={v.revision} onChange={(val) => form.setFieldValue('revision', val)} placeholder="main" disabled={loading} />
+                        <CarbonField label="Bundle name" optional small value={v.bundleName} onChange={(val) => form.setFieldValue('bundleName', val)} placeholder="qwen2.5-local" disabled={loading} />
+                    </div>
+                    <CarbonTextarea label="Include patterns" small value={v.includePatterns} onChange={(val) => form.setFieldValue('includePatterns', val)} rows={4} disabled={loading} desc="1行1パターン" />
+                    <CarbonTextarea label="Exclude patterns" small value={v.excludePatterns} onChange={(val) => form.setFieldValue('excludePatterns', val)} rows={2} disabled={loading} desc="1行1パターン" />
                     {error && (
-                        <Alert color="npm" radius="md" title="Error">{error}</Alert>
+                        <Text c="var(--af-error)" fz={12}>{error}</Text>
                     )}
-                    <Alert icon={<IconInfoCircle size={16} />} color="hf" variant="light" radius="md" title="Ollama 連携のヒント">
-                        GGUF を含むパターンを指定してダウンロードすると、同梱の README-OLLAMA.md をそのまま手順書として使えます。
-                    </Alert>
-                </Stack>
-                </FormCard>
-            </form>
+                </CarbonSection>
+
+                <CarbonFooter hint="必要ファイルを選択取得して tar 化します">
+                    {jobId && <CarbonGhostButton onClick={open}>進捗を表示</CarbonGhostButton>}
+                    <CarbonSubmit loading={loading}>取得を開始</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
+
+            <Text fz={12} c="var(--af-dim)" mt="sm" style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                <IconInfoCircle size={14} /> GGUF を含むパターンを指定すると、同梱の README-OLLAMA.md をそのまま手順書として使えます。
+            </Text>
 
             <ProgressModal
                 opened={opened}

--- a/src/app/hf/download.tsx
+++ b/src/app/hf/download.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { ProgressEvent } from '@/lib/progressBus';
-import { Alert, Badge, Button, Card, Group, Loader, Modal, PasswordInput, Progress, ScrollArea, Space, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import { Alert, Button, Group, PasswordInput, Space, Stack, Text, TextInput, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconCircleCheck, IconDownload, IconInfoCircle } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { IconArrowRight, IconDownload, IconInfoCircle } from '@tabler/icons-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FormCard } from '@/components/FormCard';
+import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
 
 type Status = 'idle' | 'starting' | 'running' | 'done' | 'error';
 
@@ -53,13 +55,11 @@ export function DownloadPane() {
         },
     });
 
-    const totals = useMemo(() => {
-        return Object.values(fileState).reduce((acc, item) => {
-            acc.received += item.received || 0;
-            acc.total += item.total || 0;
-            return acc;
-        }, { received: 0, total: 0 });
-    }, [fileState]);
+    const totals = Object.values(fileState).reduce<{ received: number; total: number }>((acc, item) => {
+        acc.received += item.received || 0;
+        acc.total += item.total || 0;
+        return acc;
+    }, { received: 0, total: 0 });
 
     const progress = totals.total > 0 ? Math.min(100, Math.floor((totals.received / totals.total) * 100)) : 0;
 
@@ -224,9 +224,30 @@ export function DownloadPane() {
         cleanupAndDelete(current);
     };
 
+    const indeterminate = status === 'starting' || status === 'running' || files.length === 0;
+    const state: 'running' | 'done' | 'error' = status === 'done' ? 'done' : status === 'error' ? 'error' : 'running';
+    const items: ProgressItem[] = files.map((file, index) => {
+        const fs = fileState[index];
+        const itemProgress = fs?.total ? Math.min(100, Math.floor(((fs.received || 0) / fs.total) * 100)) : 0;
+        const st: ProgressItem['status'] = fs?.status === 'done' ? 'done' : fs?.status === 'downloading' ? 'running' : 'waiting';
+        const name = file.path.split('/').pop() || file.path;
+        return {
+            key: `${file.path}-${index}`,
+            label: name,
+            status: st,
+            percent: itemProgress,
+            meta: st === 'done' ? '完了' : fs?.total ? `${(fs.total / 1_000_000).toFixed(1)}MB` : '待機',
+        };
+    });
+    const doneCount = items.filter((i) => i.status === 'done').length;
+
     return (
         <>
             <form onSubmit={submit}>
+                <FormCard
+                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">必要ファイルを選択取得して tar 化します</Text>}
+                    actions={<Button type="submit" loading={loading} size="md" radius="md" color="hf" rightSection={<IconArrowRight size="1.05rem" />}>取得を開始</Button>}
+                >
                 <Stack>
                     <TextInput label="Model Repo ID" placeholder="Qwen/Qwen2.5-0.5B-Instruct-GGUF" required {...form.getInputProps('repoId')} />
                     <Group grow>
@@ -237,61 +258,42 @@ export function DownloadPane() {
                     <Textarea label="Exclude patterns (1行1パターン)" minRows={2} autosize {...form.getInputProps('excludePatterns')} />
                     <PasswordInput label="Hugging Face Token (gated modelのみ必要)" placeholder="hf_xxx" {...form.getInputProps('token')} />
                     {error && (
-                        <Alert color="red" title="Error">{error}</Alert>
+                        <Alert color="npm" radius="md" title="Error">{error}</Alert>
                     )}
-                    <Alert icon={<IconInfoCircle size={16} />} color="teal" variant="light" title="Ollama 連携のヒント">
+                    <Alert icon={<IconInfoCircle size={16} />} color="hf" variant="light" radius="md" title="Ollama 連携のヒント">
                         GGUF を含むパターンを指定してダウンロードすると、同梱の README-OLLAMA.md をそのまま手順書として使えます。
                     </Alert>
-                    <Button type="submit" loading={loading} radius="lg" color="teal" leftSection={<IconDownload size="1em" />}>
-                        Hugging Face から取得開始
-                    </Button>
                 </Stack>
+                </FormCard>
             </form>
 
-            <Modal opened={opened} onClose={closeModal} size="lg" centered title="ダウンロード進捗" radius="lg">
-                <Stack>
-                    <Group justify="space-between">
-                        <Badge color={status === 'done' ? 'green' : status === 'error' ? 'red' : 'gray'} leftSection={status === 'done' ? <IconCircleCheck size="1em" /> : status === 'running' || status === 'starting' ? <Loader size="xs" color="white" /> : undefined}>
-                            {status}
-                        </Badge>
-                        {jobId && <Text size="xs" c="dimmed">jobId: {jobId}</Text>}
-                    </Group>
-                    <Progress value={progress} radius="xl" size="lg" />
-                    <Text size="xs" c="dimmed">{(totals.received / 1_000_000).toFixed(2)}MB / {(totals.total / 1_000_000).toFixed(2)}MB</Text>
-                    <ScrollArea h={320}>
-                        <Stack gap="xs">
-                            {files.map((file, index) => {
-                                const state = fileState[index];
-                                const itemProgress = state?.total ? Math.min(100, Math.floor(((state.received || 0) / state.total) * 100)) : 0;
-                                return (
-                                    <Card withBorder key={`${file.path}-${index}`}>
-                                        <Stack gap={4}>
-                                            <Group justify="space-between">
-                                                <Text size="sm" lineClamp={1}>{file.path}</Text>
-                                                <Badge size="xs" color={state?.status === 'done' ? 'green' : state?.status === 'downloading' ? 'blue' : 'gray'}>{state?.status ?? 'waiting'}</Badge>
-                                            </Group>
-                                            <Progress value={itemProgress} size="sm" radius="xl" />
-                                        </Stack>
-                                    </Card>
-                                );
-                            })}
-                        </Stack>
-                    </ScrollArea>
-
-                    <Button
-                        component="a"
-                        href={jobId ? `/api/build/download?jobId=${jobId}` : '#'}
-                        target="_blank"
-                        disabled={!jobId || status !== 'done'}
-                        leftSection={<IconDownload size="1em" />}
-                        radius="lg"
-                        color="dark"
-                        fullWidth
-                    >
-                        tar をダウンロード
-                    </Button>
-                </Stack>
-            </Modal>
+            <ProgressModal
+                opened={opened}
+                onClose={closeModal}
+                accent="hf"
+                title={state === 'done' ? '取得完了' : state === 'error' ? '取得に失敗' : '取得中'}
+                subtitle={`${form.getValues().repoId} · ${files.length} files`}
+                overallPercent={indeterminate ? undefined : progress}
+                state={state}
+                stats={[
+                    { value: doneCount, unit: `/${files.length}`, label: '完了 / 全体', accent: state === 'done' },
+                    { value: (totals.received / 1_000_000).toFixed(0), unit: ' MB', label: '取得サイズ' },
+                    { value: files.length, label: 'ファイル' },
+                ]}
+                items={items}
+                banner={state === 'done' ? <ProgressBanner tone="success" title={`${files.length} ファイルを取得しました`} detail={`${(totals.received / 1_000_000).toFixed(1)} MB`} /> : undefined}
+                footer={state === 'done' ? (
+                    <>
+                        <Button variant="default" radius="md" onClick={closeModal}>閉じる</Button>
+                        <Button color="success" radius="md" leftSection={<IconDownload size="1rem" />} component="a" href={jobId ? `/api/build/download?jobId=${jobId}` : '#'} target="_blank" disabled={!jobId}>tar をダウンロード</Button>
+                    </>
+                ) : (
+                    <>
+                        <Text className="af-mono" fz={12.5} c="var(--af-muted)">{indeterminate ? '解決しています…' : `${doneCount} / ${files.length}`}</Text>
+                        <Button variant="default" radius="md" onClick={closeModal}>キャンセル</Button>
+                    </>
+                )}
+            />
 
             <Space h="md" />
         </>

--- a/src/app/hf/page.tsx
+++ b/src/app/hf/page.tsx
@@ -1,23 +1,18 @@
 'use client';
 
 import { DownloadPane } from './download';
-import { Group, Space, Text, ThemeIcon, Title } from '@mantine/core';
-import { IconBrain } from '@tabler/icons-react';
+import { Space } from '@mantine/core';
+import { PageHeader } from '@/components/PageHeader';
 
 export default function HuggingFacePage() {
     return (
         <div>
-            <Group justify="space-between">
-                <Title>Hugging Face model</Title>
-                <ThemeIcon variant="transparent" size={60} color="teal">
-                    <IconBrain style={{ width: '70%', height: '70%' }} stroke={1.3} />
-                </ThemeIcon>
-            </Group>
-            <Text c="dimmed">
-                Hugging Face からモデルをまとめて取得し、Ollama などのローカル推論環境で使える tar アーカイブを生成します。
-            </Text>
+            <PageHeader
+                manager="hf"
+                description="GGUF 等の必要ファイルだけ選択取得し、Ollama などローカル推論で使える tar アーカイブを生成。"
+            />
 
-            <Space h="xl" />
+            <Space h="md" />
             <DownloadPane />
             <Space h="xl" />
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,23 @@
 import { MantineProvider, ColorSchemeScript, mantineHtmlProps } from "@mantine/core";
 import { ReactNode } from "react";
+import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import { DefalutLayout } from "@/components/Layout/default";
 import { theme } from "../../theme";
+import "./globals.css";
+
+const plexSans = IBM_Plex_Sans({
+    subsets: ["latin"],
+    weight: ["300", "400", "500", "600", "700"],
+    variable: "--font-plex-sans",
+    display: "swap",
+});
+
+const plexMono = IBM_Plex_Mono({
+    subsets: ["latin"],
+    weight: ["400", "500", "600"],
+    variable: "--font-plex-mono",
+    display: "swap",
+});
 
 export default function Layout({
     children
@@ -12,6 +28,7 @@ export default function Layout({
         <html
             lang="en"
             {...mantineHtmlProps}
+            className={`${plexSans.variable} ${plexMono.variable}`}
         >
             <head>
                 <ColorSchemeScript defaultColorScheme="auto"/>

--- a/src/app/npm/download.tsx
+++ b/src/app/npm/download.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { LayerCard } from "@/components/LayerCard";
 import { LockEntry } from "@/lib/progressBus";
-import { Alert, Button, Group, Modal, Progress, Space, Stack, Text, ScrollArea, Center, Loader, Badge, Textarea } from "@mantine/core";
+import { Alert, Button, Stack, Text, Textarea } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
-import { IconCircleCheck, IconDownload, IconStackFront } from "@tabler/icons-react";
+import { IconAlertTriangle, IconArrowRight, IconDownload } from "@tabler/icons-react";
 import { useCallback, useRef, useState } from "react";
 import { ProgressEvent } from "@/lib/progressBus";
+import { FormCard } from "@/components/FormCard";
+import { ProgressBanner, ProgressModal, type ProgressItem } from "@/components/ProgressModal";
 
 export function DownloadPane () {
     const [loading, setLoading] = useState(false);
@@ -56,7 +57,7 @@ export function DownloadPane () {
             const { jobId } = await res.json();
             setJobId(jobId);
             setStatus("running");
-            
+
             const es = new EventSource(`/api/build/progress?jobId=${jobId}`);
             esRef.current = es;
             es.onopen = () => {
@@ -97,59 +98,81 @@ export function DownloadPane () {
         })();
     }, [jobId, close, reset]);
 
-    const totals = Object.values(perPackage).reduce(
-        (acc, v) => {
-            acc.received += v.received || 0; acc.total! += v.total || 0; return acc;
-        },
+    const totals = Object.values(perPackage).reduce<{ received: number; total: number }>(
+        (acc, v) => { acc.received += v.received || 0; acc.total += v.total || 0; return acc; },
         { received: 0, total: 0 }
     );
-    const overallPercent = totals.total! > 0 ? Math.floor((totals.received / totals.total!) * 100) : undefined;
+    const overallPercent = totals.total > 0 ? Math.floor((totals.received / totals.total) * 100) : (status === "done" ? 100 : 0);
+    const indeterminate = status === "starting" || status === "running" || packages.length === 0;
+    const state: "running" | "done" | "error" = status === "done" ? "done" : status === "error" ? "error" : "running";
+
+    const items: ProgressItem[] = packages.map((pkg, i) => {
+        const info = perPackage[i];
+        const pct = info?.total ? Math.floor(((info.received || 0) / info.total) * 100) : 0;
+        const done = pct >= 100;
+        return {
+            key: `${i}`,
+            label: pkg.name,
+            status: done ? "done" : (info?.received ?? 0) > 0 ? "running" : "waiting",
+            percent: pct,
+            meta: done ? "完了" : info?.total ? `${(info.total / 1_000_000).toFixed(1)}MB` : "待機",
+        };
+    });
+    const doneCount = items.filter((i) => i.status === "done").length;
 
     return (
         <div>
             <Alert
                 variant="light"
-                color="yellow"
-                title="注意"
-                radius="lg"
-                my="xl"
+                color="warning"
+                icon={<IconAlertTriangle size="1.1em" />}
+                radius="md"
+                mb="lg"
             >
-                依存関係が多いパッケージは、ダウンロードに時間がかかる場合があります!
+                依存関係が多いパッケージは、ダウンロードに時間がかかる場合があります。
             </Alert>
 
             <form
                 onSubmit={form.onSubmit(onSubmit)}
             >
-                <Stack>
-                    <Textarea
-                        label="パッケージ名"
-                        description="ダウンロードしたいパッケージ名をスペースまたは改行で区切って入力"
-                        size="lg"
-                        radius="lg"
-                        placeholder="react@^18 axios"
-                        key={form.key("packages")}
-                        {...form.getInputProps("packages")}
-                        disabled={loading}
-                        minRows={5}
-                        autosize
-                    />
-                    <Space h="md" />
-                    <Button
-                        size="lg"
-                        radius="lg"
-                        type="submit"
-                        loading={loading}
-                    >
-                        Download
-                    </Button>
-                </Stack>
+                <FormCard
+                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存を全解決して tar 化します</Text>}
+                    actions={
+                        <Button
+                            size="md"
+                            radius="md"
+                            color="npm"
+                            type="submit"
+                            loading={loading}
+                            rightSection={<IconArrowRight size="1.05rem" />}
+                        >
+                            取得を開始
+                        </Button>
+                    }
+                >
+                    <Stack>
+                        <Textarea
+                            label="パッケージ名"
+                            description="ダウンロードしたいパッケージ名をスペースまたは改行で区切って入力"
+                            size="lg"
+                            radius="lg"
+                            placeholder="react@^18 axios"
+                            key={form.key("packages")}
+                            {...form.getInputProps("packages")}
+                            disabled={loading}
+                            minRows={5}
+                            autosize
+                        />
+                    </Stack>
+                </FormCard>
             </form>
 
             {jobId && !opened && status !== "idle" && (
                 <Button
                     mt="md"
                     variant="light"
-                    radius="lg"
+                    color="npm"
+                    radius="md"
                     onClick={open}
                 >
                     進捗を再表示
@@ -157,8 +180,8 @@ export function DownloadPane () {
             )}
 
             {error && <Alert
-                color="red"
-                radius="lg"
+                color="npm"
+                radius="md"
                 title="エラー"
                 my="lg"
                 variant="light"
@@ -166,145 +189,47 @@ export function DownloadPane () {
                 {error}
             </Alert>}
 
-            <Modal
+            <ProgressModal
                 opened={opened}
-                onClose={() => handleModalClose()}
-                centered
-                radius="lg"
-                size="lg"
-                transitionProps={{transition: 'pop'}}
-                withCloseButton
-            >
-                <Group
-                    justify="space-between"
-                >
-                    <Group
-                        gap="xs"
-                    >
-                        <IconStackFront />
-                        <Text
-                            fw="bold"
-                            size="lg"
+                onClose={handleModalClose}
+                accent="npm"
+                title={state === "done" ? "取得完了" : state === "error" ? "取得に失敗" : "取得中"}
+                subtitle={`${packages.length} packages`}
+                overallPercent={indeterminate ? undefined : overallPercent}
+                state={state}
+                stats={[
+                    { value: doneCount, unit: `/${packages.length}`, label: "完了 / 全体", accent: state === "done" },
+                    { value: (totals.received / 1_000_000).toFixed(0), unit: " MB", label: "取得サイズ" },
+                    { value: packages.length, label: "パッケージ" },
+                ]}
+                items={items}
+                banner={state === "done" ? (
+                    <ProgressBanner tone="success" title={`${packages.length} パッケージを取得しました`} detail={`${(totals.received / 1_000_000).toFixed(1)} MB`} />
+                ) : undefined}
+                footer={state === "done" ? (
+                    <>
+                        <Button variant="default" radius="md" onClick={handleModalClose}>閉じる</Button>
+                        <Button
+                            color="success"
+                            radius="md"
+                            leftSection={<IconDownload size="1rem" />}
+                            component="a"
+                            href={`/api/build/download?jobId=${jobId}`}
+                            target="_blank"
+                            disabled={jobId == null}
                         >
-                            ダウンロード進捗
-                        </Text>
-                    </Group>
-                    <Text
-                        size="xs"
-                    >
-                        {jobId}
-                    </Text>
-                </Group>
-
-                <Group
-                    justify="space-between"
-                >
-                    <Text
-                        size="sm"
-                        c="dimmed"
-                    >
-                        {form.getValues().packages}・{packages.length}items
-                    </Text>
-                    {status=="done" ? (
-                        <Badge
-                            leftSection={<IconCircleCheck size="1em"/>}
-                            color="green"
-                            radius="sm"
-                        >
-                            done
-                        </Badge>
-                    ):(
-                        <Badge
-                            leftSection={<Loader size="1em" color="white"/>}
-                            color="gray"
-                            radius="sm"
-                        >
-                            {status}
-                        </Badge>
-                    )}
-                </Group>
-
-                <Stack
-                    py="md"
-                    gap={10}
-                >
-                    <Group
-                        justify="space-between"
-                    >
-                        <Text
-                            fw="bold"
-                        >
-                            全体の進捗
-                        </Text>
-                        <Text>
-                            {overallPercent || 0}%
-                        </Text>
-                    </Group>
-                    <Progress
-                        value={overallPercent || 0}
-                        size="lg"
-                    />
-                    <Text
-                        color="dimmed"
-                        size="xs"
-                    >
-                        {(totals.received / 1_000_000).toFixed(2)}MB / {((totals.total ?? 0) / 1_000_000).toFixed(2)}MB
-                    </Text>
-                </Stack>
-
-                {status=="starting"||status=="running" ? (
-                    <Center
-                        h={400}
-                    >
-                        <Loader />
-                    </Center>
+                            アーカイブをダウンロード
+                        </Button>
+                    </>
                 ) : (
-                    <ScrollArea
-                        h={400}
-                    >
-                        <Stack>
-                            {packages.map((pkg, i) => {
-                                const info = perPackage[i];
-                                const pct = info?.total ? Math.floor((info.received / info.total) * 100) : undefined;
-                                return (
-                                    <LayerCard
-                                        key={i}
-                                        number={i}
-                                        status={(pct||0) >= 100 ? "done" : "process"}
-                                        progress={pct || 0}
-                                        sha={pkg.name}
-                                        total={info?.total || 0}
-                                        received={info?.received || 0}
-                                    />
-                                )
-                            })}
-                        </Stack>
-                    </ScrollArea>
+                    <>
+                        <Text className="af-mono" fz={12.5} c="var(--af-muted)">
+                            {indeterminate ? "依存を解決しています…" : `${doneCount} / ${packages.length}`}
+                        </Text>
+                        <Button variant="default" radius="md" onClick={handleModalClose}>キャンセル</Button>
+                    </>
                 )}
-
-                <Button
-                    leftSection={<IconDownload size="1rem"/>}
-                    fullWidth
-                    radius="lg"
-                    mt="lg"
-                    color="dark"
-                    disabled={jobId==null || status!="done"}
-                    component="a"
-                    href={`/api/build/download?jobId=${jobId}`}
-                    target="_blank"
-                >
-                    ダウンロード
-                </Button>
-                <Button
-                    variant="outline"
-                    fullWidth
-                    radius="lg"
-                    mt="sm"
-                    onClick={() => handleModalClose()}
-                >
-                    閉じる
-                </Button>
-            </Modal>
+            />
         </div>
     );
 }

--- a/src/app/npm/download.tsx
+++ b/src/app/npm/download.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { LockEntry } from "@/lib/progressBus";
-import { Alert, Button, Stack, Text, Textarea } from "@mantine/core";
+import { Button, Text } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
-import { IconAlertTriangle, IconArrowRight, IconDownload } from "@tabler/icons-react";
+import { IconAlertCircle, IconDownload } from "@tabler/icons-react";
 import { useCallback, useRef, useState } from "react";
 import { ProgressEvent } from "@/lib/progressBus";
-import { FormCard } from "@/components/FormCard";
 import { ProgressBanner, ProgressModal, type ProgressItem } from "@/components/ProgressModal";
+import { CarbonForm, CarbonSection, CarbonTextarea, CarbonFooter, CarbonSubmit, CarbonGhostButton, carbonClasses } from "@/components/CarbonForm";
 
 export function DownloadPane () {
     const [loading, setLoading] = useState(false);
@@ -20,6 +20,7 @@ export function DownloadPane () {
     const [perPackage, setPerPackage] = useState<Record<number, { received: number; total?: number }>>({});
     const esRef = useRef<EventSource | null>(null);
     const form = useForm({
+        mode: "controlled",
         initialValues: {
             packages: ""
         },
@@ -122,72 +123,30 @@ export function DownloadPane () {
 
     return (
         <div>
-            <Alert
-                variant="light"
-                color="warning"
-                icon={<IconAlertTriangle size="1.1em" />}
-                radius="md"
-                mb="lg"
-            >
-                依存関係が多いパッケージは、ダウンロードに時間がかかる場合があります。
-            </Alert>
+            <CarbonForm accent="npm" onSubmit={form.onSubmit(onSubmit)}>
+                <CarbonSection label="取得対象">
+                    <CarbonTextarea
+                        label={<>パッケージ名 <span className={carbonClasses.required}>必須</span></>}
+                        value={form.getValues().packages}
+                        onChange={(v) => form.setFieldValue("packages", v)}
+                        placeholder="react@^18 axios"
+                        rows={5}
+                        disabled={loading}
+                        desc="ダウンロードしたいパッケージ名をスペースまたは改行で区切って入力"
+                        error={form.errors.packages as string | undefined}
+                    />
+                </CarbonSection>
+                <CarbonFooter hint="依存を全解決して tar 化します">
+                    {jobId && <CarbonGhostButton onClick={open}>進捗を表示</CarbonGhostButton>}
+                    <CarbonSubmit loading={loading}>取得を開始</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
 
-            <form
-                onSubmit={form.onSubmit(onSubmit)}
-            >
-                <FormCard
-                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存を全解決して tar 化します</Text>}
-                    actions={
-                        <Button
-                            size="md"
-                            radius="md"
-                            color="npm"
-                            type="submit"
-                            loading={loading}
-                            rightSection={<IconArrowRight size="1.05rem" />}
-                        >
-                            取得を開始
-                        </Button>
-                    }
-                >
-                    <Stack>
-                        <Textarea
-                            label="パッケージ名"
-                            description="ダウンロードしたいパッケージ名をスペースまたは改行で区切って入力"
-                            size="lg"
-                            radius="lg"
-                            placeholder="react@^18 axios"
-                            key={form.key("packages")}
-                            {...form.getInputProps("packages")}
-                            disabled={loading}
-                            minRows={5}
-                            autosize
-                        />
-                    </Stack>
-                </FormCard>
-            </form>
-
-            {jobId && !opened && status !== "idle" && (
-                <Button
-                    mt="md"
-                    variant="light"
-                    color="npm"
-                    radius="md"
-                    onClick={open}
-                >
-                    進捗を再表示
-                </Button>
+            {error && (
+                <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
             )}
-
-            {error && <Alert
-                color="npm"
-                radius="md"
-                title="エラー"
-                my="lg"
-                variant="light"
-            >
-                {error}
-            </Alert>}
 
             <ProgressModal
                 opened={opened}

--- a/src/app/npm/page.tsx
+++ b/src/app/npm/page.tsx
@@ -62,11 +62,11 @@ export default function NpmPage() {
                     </Tabs.Tab>
                 </Tabs.List>
 
-                <Tabs.Panel value="download">
+                <Tabs.Panel value="download" py="lg">
                     <DownloadPane />
                 </Tabs.Panel>
                 {/^(1|true|on|yes)$/i.test(env.NPM_UPLOAD || '') && (
-                    <Tabs.Panel value="upload">
+                    <Tabs.Panel value="upload" py="lg">
                         <UploadPane />
                     </Tabs.Panel>
                 )}

--- a/src/app/npm/page.tsx
+++ b/src/app/npm/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Group, Space, Tabs, Text, ThemeIcon, Title } from '@mantine/core';
-import { IconBrandNpm, IconDownload, IconUpload } from '@tabler/icons-react';
+import { Space, Tabs } from '@mantine/core';
+import { IconDownload, IconUpload } from '@tabler/icons-react';
 import { DownloadPane } from './download';
 import { UploadPane } from './upload';
 import { useEffect, useState } from 'react';
 import { getEnvironmentVar } from '@/components/actions';
+import { PageHeader } from '@/components/PageHeader';
 
 export default function NpmPage() {
 
@@ -31,34 +32,17 @@ export default function NpmPage() {
 
     return (
         <div>
-            <Group
-                justify="space-between"
-            >
-                <Title>
-                    npm package
-                </Title>
-                <ThemeIcon
-                    variant="transparent"
-                    size={60}
-                >
-                    <IconBrandNpm
-                        color="red"
-                        style={{width: '70%', height: '70%'}}
-                        stroke={1.3}
-                    />
-                </ThemeIcon>
-            </Group>
-            <Text
-                c="dimmed"
-            >
-                NPM公式リポジトリから指定したパッケージとそれに依存するパッケージをダウンロードし固めたものをダウンロードします
-            </Text>
+            <PageHeader
+                manager="npm"
+                description="lockfile / name@semver から依存を全解決し、全 tarball を取得。社内レジストリへ publish も対応。"
+            />
 
-            <Space h="xl" />
-            
+            <Space h="md" />
+
             <Tabs
                 variant="pills"
-                radius="lg"
+                color="npm"
+                radius="xl"
                 defaultValue="download"
             >
                 <Tabs.List>

--- a/src/app/npm/upload.tsx
+++ b/src/app/npm/upload.tsx
@@ -4,7 +4,7 @@ import { Accordion, Alert, Button, Group, PasswordInput, Space, Stack, Text, Tex
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { Dropzone } from '@mantine/dropzone';
-import { IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from '@tabler/icons-react';
+import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from '@tabler/icons-react';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ProgressEvent } from '@/lib/progressBus';
@@ -358,10 +358,10 @@ export function UploadPane() {
         <div>
             <Alert
                 variant="light"
-                color="yellow"
-                title="注意"
-                radius="lg"
-                my="xl"
+                color="warning"
+                icon={<IconAlertTriangle size="1.1em" />}
+                radius="md"
+                mb="lg"
             >
                 大きなファイルのアップロードには時間がかかる場合があります。ブラウザを閉じると中断されます。
             </Alert>
@@ -490,14 +490,15 @@ export function UploadPane() {
                     </Stack>
 
                     <Space h="md" />
-                    <Button type="submit" size="lg" radius="lg" loading={loading}>
-                        アップロード
+                    <Button type="submit" size="md" radius="md" color="npm" loading={loading} leftSection={<IconCloudUpload size="1.1rem" />}>
+                        アップロード実行
                     </Button>
                     <Button
                         type="button"
-                        size="lg"
-                        radius="lg"
+                        size="md"
+                        radius="md"
                         variant="light"
+                        color="npm"
                         leftSection={<IconRefresh size="1.1rem" />}
                         onClick={handleRetryFailed}
                         disabled={loading || failedCount === 0}
@@ -508,12 +509,13 @@ export function UploadPane() {
             </form>
 
             {error && (
-                <Alert color="red" radius="lg" title="エラー" my="lg" variant="light">
+                <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">
                     {error}
                 </Alert>
             )}
 
             <PackageUploadModal
+                accent="npm"
                 opened={opened}
                 onClose={() => {
                     close();

--- a/src/app/npm/upload.tsx
+++ b/src/app/npm/upload.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { Accordion, Alert, Button, Group, PasswordInput, Space, Stack, Text, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { Dropzone } from '@mantine/dropzone';
-import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from '@tabler/icons-react';
+import { IconAlertCircle, IconCloudUpload, IconKey, IconRefresh, IconServer, IconX } from '@tabler/icons-react';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ProgressEvent } from '@/lib/progressBus';
@@ -13,6 +12,7 @@ import { PackageUploadModal } from '@/components/PackageUpload/Modal';
 import { getEnvironmentVar } from '@/components/actions';
 import { useRetryableEventSource } from '@/lib/useRetryableEventSource';
 import { buildAuthHeaders } from '@/lib/authHeaders';
+import { CarbonForm, CarbonSection, CarbonField, CarbonPassword, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonGhostButton, CarbonList, carbonClasses, carbonDropzoneClasses } from '@/components/CarbonForm';
 
 const FLUSH_INTERVAL = 250;
 
@@ -65,7 +65,7 @@ export function UploadPane() {
     }, []);
 
     const form = useForm<FormValues>({
-        mode: 'uncontrolled',
+        mode: 'controlled',
         initialValues: {
             files: [],
             registryUrl: '',
@@ -354,164 +354,109 @@ export function UploadPane() {
 
     const failedCount = Object.values(perFileSnap).filter((state) => state?.status === 'error').length;
 
+    const files = form.getValues().files;
+    const completed = Object.values(perFileSnap).filter((s) => s?.status === 'published' || s?.status === 'uploaded').length;
+
     return (
         <div>
-            <Alert
-                variant="light"
-                color="warning"
-                icon={<IconAlertTriangle size="1.1em" />}
-                radius="md"
-                mb="lg"
-            >
-                大きなファイルのアップロードには時間がかかる場合があります。ブラウザを閉じると中断されます。
-            </Alert>
+            <CarbonForm accent="npm" onSubmit={onSubmit}>
+                <CarbonAuthPanel
+                    icon={IconServer}
+                    title="アップロード先"
+                    sub={`${form.getValues().registryUrl?.trim() || 'レジストリ未設定'} · ${form.getValues().authToken ? 'トークン認証' : (form.getValues().username ? 'Basic 認証' : '認証なし')}`}
+                    configured={Boolean(form.getValues().registryUrl?.trim())}
+                    defaultOpen
+                >
+                    <CarbonField
+                        label="レジストリ URL"
+                        icon={IconServer}
+                        value={form.getValues().registryUrl}
+                        onChange={(v) => form.setFieldValue('registryUrl', v)}
+                        placeholder="https://nexus.example.com/repository/npm-hosted"
+                        disabled={loading}
+                    />
+                    <CarbonPassword
+                        label="Auth Token"
+                        optional
+                        icon={IconKey}
+                        value={form.getValues().authToken}
+                        onChange={(v) => form.setFieldValue('authToken', v)}
+                        placeholder="npm-xxxxxxxxxxxxxxxx"
+                        disabled={loading}
+                    />
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                        <CarbonField label="ユーザー名" optional small value={form.getValues().username} onChange={(v) => form.setFieldValue('username', v)} placeholder="username" disabled={loading} />
+                        <CarbonPassword label="パスワード" optional value={form.getValues().password} onChange={(v) => form.setFieldValue('password', v)} placeholder="password" disabled={loading} />
+                    </div>
+                </CarbonAuthPanel>
 
-            <form onSubmit={onSubmit}>
-                <Stack>
-                    <Accordion
-                        variant="separated"
-                        radius="lg"
-                    >
-                        <Accordion.Item
-                            value="upload_settings"
-                            key="upload_settings"
-                        >
-                            <Accordion.Control
-                                icon={<IconCloudCog size="1em"/>}
-                            >
-                                アップロード先設定
-                            </Accordion.Control>
-                            <Accordion.Panel>
-                                <Stack>
-                                    <TextInput
-                                        label="レジストリURL"
-                                        description="例: https://nexus.example.com/repository/npm-hosted"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="https://registry.example.com/npm"
-                                        key={form.key('registryUrl')}
-                                        {...form.getInputProps('registryUrl')}
-                                        disabled={loading}
-                                    />
-                                    <TextInput
-                                        label="Auth Token (任意)"
-                                        description="トークン認証を使用する場合に入力"
-                                        size="lg"
-                                        radius="lg"
-                                        placeholder="npm-xxxxxxxxxxxxxxxx"
-                                        key={form.key('authToken')}
-                                        {...form.getInputProps('authToken')}
-                                        disabled={loading}
-                                    />
-                                    <Group grow>
-                                        <TextInput
-                                            label="ユーザー名 (任意、トークン未使用時)"
-                                            size="lg"
-                                            radius="lg"
-                                            placeholder="username"
-                                            key={form.key('username')}
-                                            {...form.getInputProps('username')}
-                                            disabled={loading}
-                                        />
-                                        <PasswordInput
-                                            label="パスワード (任意、トークン未使用時)"
-                                            size="lg"
-                                            radius="lg"
-                                            placeholder="password"
-                                            key={form.key('password')}
-                                            {...form.getInputProps('password')}
-                                            disabled={loading}
-                                            autoComplete="current-password"
-                                        />
-                                    </Group>
-                                </Stack>
-                            </Accordion.Panel>
-                        </Accordion.Item>
-                    </Accordion>
-
+                <CarbonSection>
                     <Dropzone
-                        onDrop={(files: File[]) => form.setFieldValue('files', files)}
+                        onDrop={(dropped: File[]) => form.setFieldValue('files', dropped)}
                         accept={["application/x-tar", "application/gzip", "application/x-compressed", "application/octet-stream"]}
-                        radius="lg"
                         p="xl"
                         disabled={loading}
+                        className={carbonDropzoneClasses.root}
                     >
-                        <div style={{ pointerEvents: 'none' }}>
-                            <Group justify="center">
-                                <Dropzone.Accept>
-                                    <IconDownload size={50} color="blue.6" stroke={1.5} />
-                                </Dropzone.Accept>
-                                <Dropzone.Reject>
-                                    <IconX size={50} color="red.6" stroke={1.5} />
-                                </Dropzone.Reject>
-                                <Dropzone.Idle>
-                                    <IconCloudUpload size={50} stroke={1.5} />
-                                </Dropzone.Idle>
-                            </Group>
-                            <Text ta="center" fw={700} fz="lg" mt="xl">
-                                <Dropzone.Accept>ここにファイルをドロップ</Dropzone.Accept>
-                                <Dropzone.Idle>npm バンドルをアップロード</Dropzone.Idle>
+                        <div style={{ pointerEvents: 'none', textAlign: 'center' }}>
+                            <span className={carbonDropzoneClasses.icon}>
+                                <Dropzone.Idle><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Idle>
+                                <Dropzone.Accept><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Accept>
+                                <Dropzone.Reject><IconX size={26} stroke={1.7} /></Dropzone.Reject>
+                            </span>
+                            <div className={carbonDropzoneClasses.title}>
+                                <Dropzone.Idle>ここに .tar / .tgz をドロップ</Dropzone.Idle>
+                                <Dropzone.Accept>ここにドロップ</Dropzone.Accept>
                                 <Dropzone.Reject>対応していないファイルです</Dropzone.Reject>
-                            </Text>
-                            <Text ta="center" c="dimmed">
-                                `.tar` / `.tgz` 形式のファイルを選択してください
-                            </Text>
+                            </div>
+                            <div className={carbonDropzoneClasses.sub}>または クリックして選択 ・ 複数可</div>
                         </div>
                     </Dropzone>
 
-                    <Stack gap="xs">
-                        <Text size="sm" fw={600}>
-                            選択済みファイル ({form.getValues().files.length})
-                        </Text>
-                        {form.getValues().files.map((file, idx) => (
-                            <FileItem
-                                key={`${file.name}-${idx}`}
-                                file={file}
-                                status={perFileSnap[idx]?.status ?? 'waiting'}
-                                percent={(() => {
-                                    const info = perFileSnap[idx];
-                                    const total = info?.total ?? file.size;
-                                    const received = info?.received ?? 0;
-                                    return total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0;
-                                })()}
-                                onDelete={(target) => {
-                                    if (loading) return;
-                                    const nextFiles = form.getValues().files.filter((f) => f !== target);
-                                    form.setFieldValue('files', nextFiles);
-                                    perFileRef.current = Object.fromEntries(
-                                        nextFiles.map((f, index) => [index, { received: 0, total: f.size, status: 'waiting' }])
-                                    );
-                                    setPerFileSnap({ ...perFileRef.current });
-                                }}
-                                loading={loading}
-                                disabled={loading}
-                            />
-                        ))}
-                    </Stack>
+                    {files.length > 0 && (
+                        <CarbonList title={`キュー · ${files.length} ファイル`} right={`${completed} / ${files.length} 完了`}>
+                            {files.map((file, idx) => (
+                                <FileItem
+                                    key={`${file.name}-${idx}`}
+                                    file={file}
+                                    status={perFileSnap[idx]?.status ?? 'waiting'}
+                                    percent={(() => {
+                                        const info = perFileSnap[idx];
+                                        const total = info?.total ?? file.size;
+                                        const received = info?.received ?? 0;
+                                        return total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0;
+                                    })()}
+                                    onDelete={(target) => {
+                                        if (loading) return;
+                                        const nextFiles = files.filter((f) => f !== target);
+                                        form.setFieldValue('files', nextFiles);
+                                        perFileRef.current = Object.fromEntries(
+                                            nextFiles.map((f, index) => [index, { received: 0, total: f.size, status: 'waiting' }])
+                                        );
+                                        setPerFileSnap({ ...perFileRef.current });
+                                    }}
+                                    loading={loading}
+                                    disabled={loading}
+                                />
+                            ))}
+                        </CarbonList>
+                    )}
+                </CarbonSection>
 
-                    <Space h="md" />
-                    <Button type="submit" size="md" radius="md" color="npm" loading={loading} leftSection={<IconCloudUpload size="1.1rem" />}>
-                        アップロード実行
-                    </Button>
-                    <Button
-                        type="button"
-                        size="md"
-                        radius="md"
-                        variant="light"
-                        color="npm"
-                        leftSection={<IconRefresh size="1.1rem" />}
-                        onClick={handleRetryFailed}
-                        disabled={loading || failedCount === 0}
-                    >
-                        失敗したパッケージを再試行
-                    </Button>
-                </Stack>
-            </form>
+                <CarbonFooter hint={files.length ? `${files.length} ファイルを publish します` : 'tar / tgz を追加してください'}>
+                    {failedCount > 0 && !loading && (
+                        <CarbonGhostButton onClick={handleRetryFailed}>
+                            <IconRefresh size={15} /> 失敗を再試行
+                        </CarbonGhostButton>
+                    )}
+                    <CarbonSubmit loading={loading} icon={IconCloudUpload}>アップロード実行</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
 
             {error && (
-                <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">
-                    {error}
-                </Alert>
+                <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
             )}
 
             <PackageUploadModal

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,76 +1,25 @@
-'use client';
-import { ManagerCatalog, type ManagerEntry } from "@/components/ManagerCatalog";
-import { Center, Container, Space, Stack, Title } from "@mantine/core";
-import { IconBrandDocker, IconBrandNpm, IconBrandPython, IconBox, IconBrain } from "@tabler/icons-react";
-import Image from "next/image";
-
-const managers: ManagerEntry[] = [
-    {
-        id: "docker",
-        name: "Docker Image",
-        description: "Docker HUBのAPIを使用して安全かつ高速にDocker Imageをtarball形式でダウンロードすることができます。",
-        href: "/docker",
-        Icon: IconBrandDocker,
-        color: "blue",
-    },
-    {
-        id: "npm",
-        name: "npm package",
-        description: "npm.jsの公式レジストリを使用してnpmのない環境でも依存関係を網羅したパッケージをダウンロードすることができます。",
-        href: "/npm",
-        Icon: IconBrandNpm,
-        color: "red",
-    },
-    {
-        id: "pip",
-        name: "pip package",
-        description: "PyPI や社内レジストリから pip パッケージをまとめて取得し、任意のレジストリにアップロードできます。",
-        href: "/pip",
-        Icon: IconBrandPython,
-        color: "violet",
-    },
-    {
-        id: "hf",
-        name: "Hugging Face model",
-        description: "Hugging Face から GGUF など必要なファイルだけを選択して取得し、Ollama 等のローカル実行に使えるアーカイブを生成できます。",
-        href: "/hf",
-        Icon: IconBrain,
-        color: "teal",
-    },
-    {
-        id: "rpm",
-        name: "rpm package",
-        description: "公式リポジトリや EPEL から依存関係を含めた rpm パッケージを収集し、任意の RPM リポジトリへアップロードできます。",
-        href: "/rpm",
-        Icon: IconBox,
-        color: "yellow",
-    },
-];
+import { ManagerCatalog } from "@/components/ManagerCatalog";
+import { AccentTile } from "@/components/AccentTile";
+import { Center, Stack, Text, Title } from "@mantine/core";
 
 export default function Home() {
     return (
-        <Container
-            size="sm"
-        >
-            <Center>
-                <Image
-                    alt="icon"
-                    src="/icon.png"
-                    width={170}
-                    height={170}
-                />
-            </Center>
-            <Title
-                ta="center"
-            >
-                Artifact Fetcher
-            </Title>
-
-            <Space h="xl" />
-
-            <Stack>
-                <ManagerCatalog entries={managers} />
+        <Stack gap={48} pb="xl">
+            <Stack align="center" gap="md" pt="xl" pb="sm">
+                <AccentTile color="docker" code="AF" size="xl" />
+                <Title order={1} ta="center" style={{ letterSpacing: "-0.02em" }}>
+                    Artifact Fetcher
+                </Title>
+                <Center>
+                    <Text ta="center" c="var(--af-muted)" fz={16} lh={1.6} maw={560}>
+                        外部レジストリの成果物を依存関係ごとサーバー側で取得。閉域環境へ
+                        <Text span c="var(--af-text)"> 1 つのアーカイブ</Text>
+                        で運ぶか、社内レジストリへ直接 push。
+                    </Text>
+                </Center>
             </Stack>
-        </Container>
+
+            <ManagerCatalog />
+        </Stack>
     );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,12 @@
 import { ManagerCatalog } from "@/components/ManagerCatalog";
-import { AccentTile } from "@/components/AccentTile";
 import { Center, Stack, Text, Title } from "@mantine/core";
+import Image from "next/image";
 
 export default function Home() {
     return (
         <Stack gap={48} pb="xl">
             <Stack align="center" gap="md" pt="xl" pb="sm">
-                <AccentTile color="docker" code="AF" size="xl" />
+                <Image alt="icon" width={120} height={120} src="/icon.png" />
                 <Title order={1} ta="center" style={{ letterSpacing: "-0.02em" }}>
                     Artifact Fetcher
                 </Title>

--- a/src/app/pip/download.tsx
+++ b/src/app/pip/download.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { PipPackageCard } from '@/components/PipPackageCard';
 import { ProgressEvent, type PipPackage } from '@/lib/progressBus';
-import { Alert, Badge, Button, Center, Group, Loader, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Alert, Button, Group, Space, Stack, Text, Textarea, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconCircleCheck, IconDownload, IconStackFront } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { IconAlertTriangle, IconArrowRight, IconDownload } from '@tabler/icons-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FormCard } from '@/components/FormCard';
+import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
 
 type Status = 'idle' | 'starting' | 'running' | 'done' | 'error';
 
@@ -33,123 +34,74 @@ function PipDownloadModal({ opened, onClose, jobId, status, packages, perPackage
     packages: PipPackage[];
     perPackage: Record<number, PackageState>;
 }) {
-    const totals = useMemo(() => {
-        return Object.values(perPackage).reduce((acc, info) => {
-            acc.received += info.received || 0;
-            acc.total += info.total || 0;
-            return acc;
-        }, { received: 0, total: 0 });
-    }, [perPackage]);
-    const overallPercent = totals.total > 0 ? Math.floor((totals.received / totals.total) * 100) : undefined;
+    const totals = Object.values(perPackage).reduce((acc, info) => {
+        acc.received += info.received || 0;
+        acc.total += info.total || 0;
+        return acc;
+    }, { received: 0, total: 0 });
+    const indeterminate = status === 'starting' || status === 'running' || packages.length === 0;
+    const overallPercent = totals.total > 0 ? Math.floor((totals.received / totals.total) * 100) : (status === 'done' ? 100 : 0);
+    const state: 'running' | 'done' | 'error' = status === 'done' ? 'done' : status === 'error' ? 'error' : 'running';
 
-    const statusBadge = (() => {
-        switch (status) {
-            case 'done':
-                return (
-                    <Badge color="green" leftSection={<IconCircleCheck size="1em" />} radius="sm">
-                        done
-                    </Badge>
-                );
-            case 'error':
-                return (
-                    <Badge color="red" radius="sm">
-                        error
-                    </Badge>
-                );
-            case 'running':
-            case 'starting':
-                return (
-                    <Badge color="gray" leftSection={<Loader size="1em" color="white" />} radius="sm">
-                        {status}
-                    </Badge>
-                );
-            default:
-                return (
-                    <Badge color="gray" radius="sm">
-                        idle
-                    </Badge>
-                );
-        }
-    })();
+    const items: ProgressItem[] = packages.map((pkg, idx) => {
+        const info = perPackage[idx];
+        const raw = info?.status ?? 'waiting';
+        const pct = info?.total ? Math.floor(((info.received || 0) / info.total) * 100) : 0;
+        const st: ProgressItem['status'] =
+            raw === 'done' ? 'done' :
+            (info?.received ?? 0) > 0 || raw === 'downloading' ? 'running' : 'waiting';
+        return {
+            key: `${pkg.name}-${idx}`,
+            label: `${pkg.name} ${pkg.version}`,
+            status: st,
+            percent: pct,
+            meta: st === 'done' ? '完了' : info?.total ? `${(info.total / 1_000_000).toFixed(1)}MB` : '待機',
+        };
+    });
+    const doneCount = items.filter((i) => i.status === 'done').length;
 
     return (
-        <Modal
+        <ProgressModal
             opened={opened}
             onClose={onClose}
-            centered
-            radius="lg"
-            size="lg"
-            transitionProps={{ transition: 'pop' }}
-            withCloseButton
-        >
-            <Stack gap="md">
-                <Group justify="space-between">
-                    <Group gap="xs">
-                        <IconStackFront />
-                        <Text fw="bold" size="lg">
-                            ダウンロード進捗
-                        </Text>
-                    </Group>
-                    {statusBadge}
-                </Group>
-                {jobId && (
-                    <Text size="xs" c="dimmed">
-                        jobId: {jobId}
+            accent="pip"
+            title={state === 'done' ? '取得完了' : state === 'error' ? '取得に失敗' : '取得中'}
+            subtitle={`${packages.length} packages`}
+            overallPercent={indeterminate ? undefined : overallPercent}
+            state={state}
+            stats={[
+                { value: doneCount, unit: `/${packages.length}`, label: '完了 / 全体', accent: state === 'done' },
+                { value: (totals.received / 1_000_000).toFixed(0), unit: ' MB', label: '取得サイズ' },
+                { value: packages.length, label: 'パッケージ' },
+            ]}
+            items={items}
+            banner={state === 'done' ? (
+                <ProgressBanner tone="success" title={`${packages.length} パッケージを取得しました`} detail={`${(totals.received / 1_000_000).toFixed(1)} MB`} />
+            ) : undefined}
+            footer={state === 'done' ? (
+                <>
+                    <Button variant="default" radius="md" onClick={onClose}>閉じる</Button>
+                    <Button
+                        color="success"
+                        radius="md"
+                        leftSection={<IconDownload size="1rem" />}
+                        component="a"
+                        href={jobId ? `/api/build/download?jobId=${jobId}` : '#'}
+                        target="_blank"
+                        disabled={!jobId}
+                    >
+                        アーカイブをダウンロード
+                    </Button>
+                </>
+            ) : (
+                <>
+                    <Text className="af-mono" fz={12.5} c="var(--af-muted)">
+                        {indeterminate ? '依存を解決しています…' : `${doneCount} / ${packages.length}`}
                     </Text>
-                )}
-
-                <Stack gap={10} py="xs">
-                    <Group justify="space-between">
-                        <Text fw="bold">全体の進捗</Text>
-                        <Text>{overallPercent ?? 0}%</Text>
-                    </Group>
-                    <Progress value={overallPercent ?? 0} size="lg" radius="xl" />
-                    <Text size="xs" c="dimmed">
-                        {(totals.received / 1_000_000).toFixed(2)}MB / {(totals.total / 1_000_000).toFixed(2)}MB
-                    </Text>
-                </Stack>
-
-                {status === 'starting' || status === 'running' ? (
-                    <Center h={420}>
-                        <Loader />
-                    </Center>
-                ) : (
-                    <ScrollArea h={420}>
-                        <Stack gap="sm">
-                            {packages.map((pkg, idx) => {
-                                const info = perPackage[idx];
-                                return (
-                                    <PipPackageCard
-                                        key={`${pkg.name}-${pkg.version}-${idx}`}
-                                        index={idx}
-                                        name={pkg.name}
-                                        version={pkg.version}
-                                        filename={pkg.filename}
-                                        received={info?.received ?? 0}
-                                        total={info?.total}
-                                        status={info?.status ?? 'waiting'}
-                                    />
-                                );
-                            })}
-                        </Stack>
-                    </ScrollArea>
-                )}
-
-                <Button
-                    leftSection={<IconDownload size="1em" />}
-                    fullWidth
-                    radius="lg"
-                    mt="md"
-                    color="dark"
-                    disabled={!jobId || status !== 'done'}
-                    component="a"
-                    href={jobId ? `/api/build/download?jobId=${jobId}` : '#'}
-                    target="_blank"
-                >
-                    ダウンロード
-                </Button>
-            </Stack>
-        </Modal>
+                    <Button variant="default" radius="md" onClick={onClose}>キャンセル</Button>
+                </>
+            )}
+        />
     );
 }
 
@@ -360,11 +312,19 @@ export function DownloadPane() {
 
     return (
         <div>
-            <Alert variant="light" color="yellow" title="注意" radius="lg" my="xl">
+            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">
                 依存パッケージが多い場合は、ダウンロードに時間がかかることがあります。ブラウザを閉じると処理が中断されます。
             </Alert>
 
             <form onSubmit={form.onSubmit(onSubmit)}>
+                <FormCard
+                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存込みで取得して tar 化します</Text>}
+                    actions={
+                        <Button type="submit" size="md" radius="md" color="pip" loading={loading} rightSection={<IconArrowRight size="1.05rem" />}>
+                            取得を開始
+                        </Button>
+                    }
+                >
                 <Stack>
                     <Textarea
                         label="パッケージ名"
@@ -439,21 +399,18 @@ export function DownloadPane() {
                         disabled={loading}
                     />
 
-                    <Space h="md" />
-                    <Button type="submit" size="lg" radius="lg" loading={loading}>
-                        ジョブ開始
-                    </Button>
                 </Stack>
+                </FormCard>
             </form>
 
             {jobId && !opened && status !== 'idle' && (
-                <Button mt="md" variant="light" radius="lg" onClick={open}>
+                <Button mt="md" variant="light" color="pip" radius="md" onClick={open}>
                     進捗を再表示
                 </Button>
             )}
 
             {error && (
-                <Alert color="red" radius="lg" title="エラー" my="lg" variant="light">
+                <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">
                     {error}
                 </Alert>
             )}

--- a/src/app/pip/download.tsx
+++ b/src/app/pip/download.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ProgressEvent, type PipPackage } from '@/lib/progressBus';
-import { Alert, Button, Group, Space, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Alert, Button, Group, Stack, Text, Textarea, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { IconAlertTriangle, IconArrowRight, IconDownload } from '@tabler/icons-react';

--- a/src/app/pip/download.tsx
+++ b/src/app/pip/download.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { ProgressEvent, type PipPackage } from '@/lib/progressBus';
-import { Alert, Button, Group, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Button, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconAlertTriangle, IconArrowRight, IconDownload } from '@tabler/icons-react';
+import { IconAlertCircle, IconBox, IconDownload, IconWorld } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FormCard } from '@/components/FormCard';
 import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
+import { CarbonForm, CarbonSection, CarbonField, CarbonTextarea, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonGhostButton, carbonClasses } from '@/components/CarbonForm';
 
 type Status = 'idle' | 'starting' | 'running' | 'done' | 'error';
 
@@ -116,6 +116,7 @@ export function DownloadPane() {
     const esRef = useRef<EventSource | null>(null);
 
     const form = useForm<FormValues>({
+        mode: 'controlled',
         initialValues: {
             packages: '',
             requirementsText: '',
@@ -312,107 +313,92 @@ export function DownloadPane() {
 
     return (
         <div>
-            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">
-                依存パッケージが多い場合は、ダウンロードに時間がかかることがあります。ブラウザを閉じると処理が中断されます。
-            </Alert>
-
-            <form onSubmit={form.onSubmit(onSubmit)}>
-                <FormCard
-                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存込みで取得して tar 化します</Text>}
-                    actions={
-                        <Button type="submit" size="md" radius="md" color="pip" loading={loading} rightSection={<IconArrowRight size="1.05rem" />}>
-                            取得を開始
-                        </Button>
-                    }
+            <CarbonForm accent="pip" onSubmit={form.onSubmit(onSubmit)}>
+                <CarbonAuthPanel
+                    icon={IconWorld}
+                    title="インデックス / 設定"
+                    sub={`${form.getValues().indexUrl?.trim() || 'pypi.org/simple'} · ${form.getValues().trustedHosts?.trim() ? 'TLS 検証スキップあり' : 'TLS 検証 ON'}`}
+                    configured={Boolean(form.getValues().indexUrl?.trim())}
+                    defaultOpen={false}
                 >
-                <Stack>
-                    <Textarea
-                        label="パッケージ名"
-                        description="例: requests==2.31.0 fastapi"
-                        size="lg"
-                        radius="lg"
-                        placeholder="requests==2.31.0"
-                        key={form.key('packages')}
-                        {...form.getInputProps('packages')}
-                        minRows={5}
-                        autosize
+                    <CarbonField
+                        label="Index URL"
+                        optional
+                        small
+                        icon={IconWorld}
+                        value={form.getValues().indexUrl}
+                        onChange={(val) => form.setFieldValue('indexUrl', val)}
+                        placeholder="https://pypi.org/simple"
                         disabled={loading}
+                        desc="社内 PyPI などを利用する場合に指定"
                     />
-                    <Textarea
-                        label="requirements.txt (任意)"
-                        description="requirements.txt の内容を貼り付けるとそのまま使用します"
-                        size="lg"
-                        radius="lg"
-                        placeholder="# requirements.txt"
-                        key={form.key('requirementsText')}
-                        {...form.getInputProps('requirementsText')}
-                        minRows={6}
-                        autosize
-                        disabled={loading}
-                    />
-                    <Group grow>
-                        <TextInput
-                            label="バンドル名"
-                            description="出力tarファイル名のベースになります"
-                            size="lg"
-                            radius="lg"
-                            placeholder="pip-offline"
-                            key={form.key('bundleName')}
-                            {...form.getInputProps('bundleName')}
-                            disabled={loading}
-                        />
-                        <TextInput
-                            label="Index URL (任意)"
-                            description="社内PyPIなどを利用する場合に指定"
-                            size="lg"
-                            radius="lg"
-                            placeholder="https://pypi.org/simple"
-                            key={form.key('indexUrl')}
-                            {...form.getInputProps('indexUrl')}
-                            disabled={loading}
-                        />
-                    </Group>
-
-                    <Textarea
-                        label="Extra Index URLs (任意)"
-                        description="複数指定する場合は改行またはカンマ区切りで入力"
-                        size="lg"
-                        radius="lg"
+                    <CarbonTextarea
+                        label="Extra Index URLs"
+                        optional
+                        small
+                        value={form.getValues().extraIndexUrls}
+                        onChange={(val) => form.setFieldValue('extraIndexUrls', val)}
                         placeholder={`https://internal.example.com/simple\nhttps://another.example.com/simple`}
-                        key={form.key('extraIndexUrls')}
-                        {...form.getInputProps('extraIndexUrls')}
-                        minRows={3}
-                        autosize
+                        rows={3}
                         disabled={loading}
+                        desc="複数指定する場合は改行またはカンマ区切り"
                     />
-
-                    <Textarea
-                        label="Trusted Hosts (任意)"
-                        description="セルフサイン証明書などでTLS検証をスキップする場合に指定"
-                        size="lg"
-                        radius="lg"
-                        placeholder={`nexus.example.com`}
-                        key={form.key('trustedHosts')}
-                        {...form.getInputProps('trustedHosts')}
-                        minRows={2}
-                        autosize
+                    <CarbonTextarea
+                        label="Trusted Hosts"
+                        optional
+                        small
+                        value={form.getValues().trustedHosts}
+                        onChange={(val) => form.setFieldValue('trustedHosts', val)}
+                        placeholder="nexus.example.com"
+                        rows={2}
                         disabled={loading}
+                        desc="自己署名証明書で TLS 検証をスキップする場合に指定"
                     />
+                </CarbonAuthPanel>
 
-                </Stack>
-                </FormCard>
-            </form>
+                <CarbonSection label="取得対象">
+                    <CarbonTextarea
+                        label={<>パッケージ名 <span className={carbonClasses.required}>必須</span></>}
+                        value={form.getValues().packages}
+                        onChange={(val) => form.setFieldValue('packages', val)}
+                        placeholder="requests==2.31.0 fastapi"
+                        rows={5}
+                        disabled={loading}
+                        desc="例: requests==2.31.0 fastapi"
+                        error={form.errors.packages as string | undefined}
+                    />
+                    <CarbonTextarea
+                        label="requirements.txt"
+                        optional
+                        value={form.getValues().requirementsText}
+                        onChange={(val) => form.setFieldValue('requirementsText', val)}
+                        placeholder="# requirements.txt"
+                        rows={6}
+                        disabled={loading}
+                        desc="内容を貼り付けるとそのまま使用します"
+                    />
+                    <CarbonField
+                        label="バンドル名"
+                        optional
+                        icon={IconBox}
+                        value={form.getValues().bundleName}
+                        onChange={(val) => form.setFieldValue('bundleName', val)}
+                        placeholder="pip-offline"
+                        disabled={loading}
+                        desc="出力 tar ファイル名のベースになります"
+                    />
+                </CarbonSection>
 
-            {jobId && !opened && status !== 'idle' && (
-                <Button mt="md" variant="light" color="pip" radius="md" onClick={open}>
-                    進捗を再表示
-                </Button>
-            )}
+                <CarbonFooter hint="依存込みで取得して tar 化します">
+                    {jobId && status !== 'idle' && <CarbonGhostButton onClick={open}>進捗を表示</CarbonGhostButton>}
+                    <CarbonSubmit loading={loading}>取得を開始</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
 
             {error && (
-                <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">
-                    {error}
-                </Alert>
+                <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
             )}
 
             <PipDownloadModal

--- a/src/app/pip/page.tsx
+++ b/src/app/pip/page.tsx
@@ -3,9 +3,10 @@
 import { getEnvironmentVar } from '@/components/actions';
 import { DownloadPane } from './download';
 import { UploadPane } from './upload';
-import { Group, Space, Tabs, Text, ThemeIcon, Title } from '@mantine/core';
-import { IconBrandPython, IconDownload, IconUpload } from '@tabler/icons-react';
+import { Space, Tabs } from '@mantine/core';
+import { IconDownload, IconUpload } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
+import { PageHeader } from '@/components/PageHeader';
 
 type PipEnv = {
     PIP_UPLOAD: string;
@@ -43,19 +44,14 @@ export default function PipPage() {
 
     return (
         <div>
-            <Group justify="space-between">
-                <Title>pip package</Title>
-                <ThemeIcon variant="transparent" size={60} color="violet">
-                    <IconBrandPython style={{ width: '70%', height: '70%' }} stroke={1.3} />
-                </ThemeIcon>
-            </Group>
-            <Text c="dimmed">
-                PyPI や社内レジストリから依存関係を含めた pip パッケージをダウンロードし、tar アーカイブとして取得できます。また、任意の Python パッケージレジストリにアップロードできます。
-            </Text>
+            <PageHeader
+                manager="pip"
+                description="PyPI / 社内インデックスから依存込みでまとめて取得し、tar アーカイブ化。任意のレジストリへアップロードも可能。"
+            />
 
-            <Space h="xl" />
+            <Space h="md" />
 
-            <Tabs variant="pills" radius="lg" defaultValue="download">
+            <Tabs variant="pills" color="pip" radius="xl" defaultValue="download">
                 <Tabs.List>
                     <Tabs.Tab value="download" leftSection={<IconDownload size="1em" />}>
                         ダウンロード

--- a/src/app/pip/page.tsx
+++ b/src/app/pip/page.tsx
@@ -65,11 +65,11 @@ export default function PipPage() {
                     </Tabs.Tab>
                 </Tabs.List>
 
-                <Tabs.Panel value="download">
+                <Tabs.Panel value="download" py="lg">
                     <DownloadPane />
                 </Tabs.Panel>
                 {uploadEnabled && (
-                    <Tabs.Panel value="upload">
+                    <Tabs.Panel value="upload" py="lg">
                         <UploadPane env={env} />
                     </Tabs.Panel>
                 )}

--- a/src/app/pip/upload.tsx
+++ b/src/app/pip/upload.tsx
@@ -8,7 +8,7 @@ import { Accordion, Alert, Button, Checkbox, FileInput, Group, PasswordInput, Sp
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { Dropzone } from '@mantine/dropzone';
-import { IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from '@tabler/icons-react';
+import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from '@tabler/icons-react';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FileItem } from '@/components/Upload/FileItem';
@@ -390,7 +390,7 @@ export function UploadPane({ env }: { env: EnvProps }) {
 
     return (
         <div>
-            <Alert variant="light" color="yellow" title="注意" radius="lg" my="xl">
+            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">
                 大きなファイルのアップロードには時間がかかる場合があります。ブラウザを閉じると中断されます。
             </Alert>
 
@@ -545,14 +545,15 @@ export function UploadPane({ env }: { env: EnvProps }) {
                     </Stack>
 
                     <Space h="md" />
-                    <Button type="submit" size="lg" radius="lg" loading={loading}>
-                        アップロード
+                    <Button type="submit" size="md" radius="md" color="pip" loading={loading} leftSection={<IconCloudUpload size="1.1rem" />}>
+                        アップロード実行
                     </Button>
                     <Button
                         type="button"
-                        size="lg"
-                        radius="lg"
+                        size="md"
+                        radius="md"
                         variant="light"
+                        color="pip"
                         leftSection={<IconRefresh size="1.1rem" />}
                         onClick={handleRetryFailed}
                         disabled={loading || failedCount === 0}
@@ -563,12 +564,13 @@ export function UploadPane({ env }: { env: EnvProps }) {
             </form>
 
             {error && (
-                <Alert color="red" radius="lg" title="エラー" my="lg" variant="light">
+                <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">
                     {error}
                 </Alert>
             )}
 
             <PackageUploadModal
+                accent="pip"
                 opened={opened}
                 onClose={() => {
                     close();

--- a/src/app/pip/upload.tsx
+++ b/src/app/pip/upload.tsx
@@ -4,11 +4,12 @@ import { PackageUploadModal } from '@/components/PackageUpload/Modal';
 import { ProgressEvent } from '@/lib/progressBus';
 import { useRetryableEventSource } from '@/lib/useRetryableEventSource';
 import { buildAuthHeaders } from '@/lib/authHeaders';
-import { Accordion, Alert, Button, Checkbox, FileInput, Group, PasswordInput, Space, Stack, Text, TextInput } from '@mantine/core';
+import { FileInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { Dropzone } from '@mantine/dropzone';
-import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconRefresh, IconX } from '@tabler/icons-react';
+import { IconAlertCircle, IconCloudUpload, IconKey, IconRefresh, IconServer, IconX } from '@tabler/icons-react';
+import { CarbonForm, CarbonSection, CarbonField, CarbonPassword, CarbonCheckbox, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonGhostButton, CarbonList, carbonClasses, carbonDropzoneClasses } from '@/components/CarbonForm';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FileItem } from '@/components/Upload/FileItem';
@@ -82,7 +83,7 @@ export function UploadPane({ env }: { env: EnvProps }) {
     }, []);
 
     const form = useForm<FormValues>({
-        mode: 'uncontrolled',
+        mode: 'controlled',
         initialValues: {
             files: [],
             repositoryUrl: env.PIP_UPLOAD_REGISTRY || '',
@@ -388,98 +389,42 @@ export function UploadPane({ env }: { env: EnvProps }) {
 
     const failedCount = Object.values(perFileSnap).filter((state) => state?.status === 'error').length;
 
+    const files = form.getValues().files;
+    const completed = Object.values(perFileSnap).filter((s) => s?.status === 'published' || s?.status === 'uploaded').length;
+
     return (
         <div>
-            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">
-                大きなファイルのアップロードには時間がかかる場合があります。ブラウザを閉じると中断されます。
-            </Alert>
+            <CarbonForm accent="pip" onSubmit={onSubmit}>
+                <CarbonAuthPanel
+                    icon={IconServer}
+                    title="アップロード先"
+                    sub={`${form.getValues().repositoryUrl?.trim() || 'レジストリ未設定'} · ${form.getValues().token ? 'トークン認証' : (form.getValues().username ? 'Basic 認証' : '認証なし')}`}
+                    configured={Boolean(form.getValues().repositoryUrl?.trim())}
+                    defaultOpen
+                >
+                    <CarbonField label="レジストリ URL" icon={IconServer} value={form.getValues().repositoryUrl} onChange={(v) => form.setFieldValue('repositoryUrl', v)} placeholder="https://nexus.example.com/repository/pypi-hosted/" disabled={loading} />
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                        <CarbonField label="ユーザー名" optional small value={form.getValues().username} onChange={(v) => form.setFieldValue('username', v)} placeholder="username" disabled={loading} />
+                        <CarbonPassword label="パスワード" optional value={form.getValues().password} onChange={(v) => form.setFieldValue('password', v)} placeholder="password" disabled={loading} />
+                    </div>
+                    <CarbonPassword label="トークン" optional icon={IconKey} value={form.getValues().token} onChange={(v) => form.setFieldValue('token', v)} placeholder="pypi-xxxxxxxxxxxx" disabled={loading} />
+                    <CarbonCheckbox checked={form.getValues().skipExisting} onChange={(c) => form.setFieldValue('skipExisting', c)} label="すでに存在する場合はスキップ (--skip-existing)" disabled={loading} />
+                    <FileInput
+                        label="信頼済み証明書 (任意)"
+                        description="自己署名や社内CAの場合は PEM 形式の証明書を指定"
+                        placeholder=".pem / .crt"
+                        radius="md"
+                        value={form.getValues().caCert || null}
+                        onChange={(file) => form.setFieldValue('caCert', file)}
+                        disabled={loading}
+                        accept={'.pem,.crt,.cer'}
+                        clearable
+                    />
+                </CarbonAuthPanel>
 
-            <form onSubmit={onSubmit}>
-                <Stack>
-                    <Accordion
-                        variant="separated"
-                        radius="lg"
-                    >
-                        <Accordion.Item
-                            value="upload_settings"
-                            key="upload_settings"
-                        >
-                            <Accordion.Control
-                                icon={<IconCloudCog size="1em"/>}
-                            >
-                                アップロード先設定
-                            </Accordion.Control>
-                            <Accordion.Panel>
-                                <Stack>
-                                    <Stack>
-                                        <TextInput
-                                            label="レジストリURL"
-                                            description="例: https://nexus.example.com/repository/pypi-hosted/"
-                                            size="lg"
-                                            radius="lg"
-                                            placeholder="https://pypi.example.com/"
-                                            key={form.key('repositoryUrl')}
-                                            {...form.getInputProps('repositoryUrl')}
-                                            disabled={loading}
-                                        />
-                                        <Group grow>
-                                            <TextInput
-                                                label="ユーザー名 (任意)"
-                                                size="lg"
-                                                radius="lg"
-                                                placeholder="username"
-                                                key={form.key('username')}
-                                                {...form.getInputProps('username')}
-                                                disabled={loading}
-                                            />
-                                            <PasswordInput
-                                                label="パスワード (任意)"
-                                                size="lg"
-                                                radius="lg"
-                                                placeholder="password"
-                                                key={form.key('password')}
-                                                {...form.getInputProps('password')}
-                                                disabled={loading}
-                                                autoComplete="current-password"
-                                            />
-                                        </Group>
-                                        <TextInput
-                                            label="トークン (任意)"
-                                            description="API Token を使用する場合に入力"
-                                            size="lg"
-                                            radius="lg"
-                                            placeholder="pypi-xxxxxxxxxxxx"
-                                            key={form.key('token')}
-                                            {...form.getInputProps('token')}
-                                            disabled={loading}
-                                        />
-                                        <Checkbox
-                                            label="すでに存在する場合はスキップ (--skip-existing)"
-                                            key={form.key('skipExisting')}
-                                            {...form.getInputProps('skipExisting', { type: 'checkbox' })}
-                                            disabled={loading}
-                                        />
-                                        <FileInput
-                                            label="信頼済み証明書 (任意)"
-                                            description="自己署名や社内CAの場合は PEM 形式の証明書を指定してください"
-                                            placeholder=".pem / .crt"
-                                            size="lg"
-                                            radius="lg"
-                                            key={form.key('caCert')}
-                                            value={form.getValues().caCert || null}
-                                            onChange={(file) => form.setFieldValue('caCert', file)}
-                                            disabled={loading}
-                                            accept={'.pem,.crt,.cer'}
-                                            clearable
-                                        />
-                                    </Stack>
-                                </Stack>
-                            </Accordion.Panel>
-                        </Accordion.Item>
-                    </Accordion>
-
+                <CarbonSection>
                     <Dropzone
-                        onDrop={(files) => form.setFieldValue('files', files)}
+                        onDrop={(dropped) => form.setFieldValue('files', dropped)}
                         accept={{
                             "application/zip": [".zip", ".whl"],
                             "application/vnd.python.wheel": [".whl"],
@@ -487,86 +432,67 @@ export function UploadPane({ env }: { env: EnvProps }) {
                             "application/x-tar": [".tar.gz"],
                             "application/gzip": [".tar.gz"]
                         }}
-                        radius="lg"
                         p="xl"
                         disabled={loading}
+                        className={carbonDropzoneClasses.root}
                     >
-                        <div style={{ pointerEvents: 'none' }}>
-                            <Group justify="center">
-                                <Dropzone.Accept>
-                                    <IconDownload size={50} color="blue.6" stroke={1.5} />
-                                </Dropzone.Accept>
-                                <Dropzone.Reject>
-                                    <IconX size={50} color="red.6" stroke={1.5} />
-                                </Dropzone.Reject>
-                                <Dropzone.Idle>
-                                    <IconCloudUpload size={50} stroke={1.5} />
-                                </Dropzone.Idle>
-                            </Group>
-                            <Text ta="center" fw={700} fz="lg" mt="xl">
-                                <Dropzone.Accept>ここにファイルをドロップ</Dropzone.Accept>
-                                <Dropzone.Idle>.whl/.tar.gz/.zip をアップロード</Dropzone.Idle>
+                        <div style={{ pointerEvents: 'none', textAlign: 'center' }}>
+                            <span className={carbonDropzoneClasses.icon}>
+                                <Dropzone.Idle><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Idle>
+                                <Dropzone.Accept><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Accept>
+                                <Dropzone.Reject><IconX size={26} stroke={1.7} /></Dropzone.Reject>
+                            </span>
+                            <div className={carbonDropzoneClasses.title}>
+                                <Dropzone.Idle>.whl / .tar.gz / .zip をドロップ</Dropzone.Idle>
+                                <Dropzone.Accept>ここにドロップ</Dropzone.Accept>
                                 <Dropzone.Reject>対応していないファイルです</Dropzone.Reject>
-                            </Text>
-                            <Text ta="center" c="dimmed">
-                                ビルド済みの Wheel またはソースディストリビューションを選択してください
-                            </Text>
+                            </div>
+                            <div className={carbonDropzoneClasses.sub}>または クリックして選択 ・ 複数可</div>
                         </div>
                     </Dropzone>
 
-                    <Stack gap="xs">
-                        <Text size="sm" fw={600}>
-                            選択済みファイル ({form.getValues().files.length})
-                        </Text>
-                        {form.getValues().files.map((file, idx) => (
-                            <FileItem
-                                key={`${file.name}-${idx}`}
-                                file={file}
-                                status={perFileSnap[idx]?.status ?? 'waiting'}
-                                percent={(() => {
-                                    const info = perFileSnap[idx];
-                                    const total = info?.total ?? file.size;
-                                    const received = info?.received ?? 0;
-                                    return total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0;
-                                })()}
-                                onDelete={(target) => {
-                                    if (loading) return;
-                                    const nextFiles = form.getValues().files.filter((f) => f !== target);
-                                    form.setFieldValue('files', nextFiles);
-                                    perFileRef.current = Object.fromEntries(
-                                        nextFiles.map((f, index) => [index, { received: 0, total: f.size, status: 'waiting' }])
-                                    );
-                                    setPerFileSnap({ ...perFileRef.current });
-                                }}
-                                loading={loading}
-                                disabled={loading}
-                            />
-                        ))}
-                    </Stack>
+                    {files.length > 0 && (
+                        <CarbonList title={`キュー · ${files.length} ファイル`} right={`${completed} / ${files.length} 完了`}>
+                            {files.map((file, idx) => (
+                                <FileItem
+                                    key={`${file.name}-${idx}`}
+                                    file={file}
+                                    status={perFileSnap[idx]?.status ?? 'waiting'}
+                                    percent={(() => {
+                                        const info = perFileSnap[idx];
+                                        const total = info?.total ?? file.size;
+                                        const received = info?.received ?? 0;
+                                        return total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0;
+                                    })()}
+                                    onDelete={(target) => {
+                                        if (loading) return;
+                                        const nextFiles = files.filter((f) => f !== target);
+                                        form.setFieldValue('files', nextFiles);
+                                        perFileRef.current = Object.fromEntries(
+                                            nextFiles.map((f, index) => [index, { received: 0, total: f.size, status: 'waiting' }])
+                                        );
+                                        setPerFileSnap({ ...perFileRef.current });
+                                    }}
+                                    loading={loading}
+                                    disabled={loading}
+                                />
+                            ))}
+                        </CarbonList>
+                    )}
+                </CarbonSection>
 
-                    <Space h="md" />
-                    <Button type="submit" size="md" radius="md" color="pip" loading={loading} leftSection={<IconCloudUpload size="1.1rem" />}>
-                        アップロード実行
-                    </Button>
-                    <Button
-                        type="button"
-                        size="md"
-                        radius="md"
-                        variant="light"
-                        color="pip"
-                        leftSection={<IconRefresh size="1.1rem" />}
-                        onClick={handleRetryFailed}
-                        disabled={loading || failedCount === 0}
-                    >
-                        失敗したパッケージを再試行
-                    </Button>
-                </Stack>
-            </form>
+                <CarbonFooter hint={files.length ? `${files.length} ファイルを publish します` : '.whl / .tar.gz / .zip を追加してください'}>
+                    {failedCount > 0 && !loading && (
+                        <CarbonGhostButton onClick={handleRetryFailed}><IconRefresh size={15} /> 失敗を再試行</CarbonGhostButton>
+                    )}
+                    <CarbonSubmit loading={loading} icon={IconCloudUpload}>アップロード実行</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
 
             {error && (
-                <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">
-                    {error}
-                </Alert>
+                <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
             )}
 
             <PackageUploadModal

--- a/src/app/rpm/download.tsx
+++ b/src/app/rpm/download.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { ProgressEvent, type RpmPackage } from '@/lib/progressBus';
-import { Alert, Button, Checkbox, ScrollArea, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Button, ScrollArea, Stack, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconAlertTriangle, IconArrowRight, IconDownload } from '@tabler/icons-react';
+import { IconAlertCircle, IconBox, IconDownload } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FormCard } from '@/components/FormCard';
 import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
+import { CarbonForm, CarbonSection, CarbonField, CarbonTextarea, CarbonCheckbox, CarbonFooter, CarbonSubmit, carbonClasses } from '@/components/CarbonForm';
 
 const repoOptions = [
     { value: 'centos-stream-9-baseos', label: 'CentOS Stream 9 BaseOS (official)' },
@@ -66,6 +66,7 @@ export function DownloadPane() {
     const esRef = useRef<EventSource | null>(null);
 
     const form = useForm({
+        mode: 'controlled',
         initialValues: {
             packages: '',
             bundleName: 'rpm-offline',
@@ -198,34 +199,79 @@ export function DownloadPane() {
     });
     const doneCount = items.filter((i) => i.status === 'done').length;
 
+    const fv = form.getValues();
+    const toggleRepo = (value: string) => {
+        const cur = fv.repositories;
+        form.setFieldValue('repositories', cur.includes(value) ? cur.filter((r) => r !== value) : [...cur, value]);
+    };
     return (
         <div>
-            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">依存関係解決を有効にすると、対象パッケージが多くなるため時間がかかる場合があります。</Alert>
-            <form onSubmit={form.onSubmit(onSubmit)}>
-                <FormCard
-                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存込みで収集して tar 化します</Text>}
-                    actions={<Button size="md" radius="md" color="rpm" type="submit" loading={loading} rightSection={<IconArrowRight size="1.05rem" />}>取得を開始</Button>}
-                >
-                <Stack>
-                    <Textarea label="Package" description="rpm名をスペースまたは改行区切りで入力" minRows={4} autosize size="lg" radius="lg" placeholder="bash\ncoreutils" key={form.key('packages')} {...form.getInputProps('packages')} disabled={loading} />
-                    <TextInput label="Bundle name" size="lg" radius="lg" key={form.key('bundleName')} {...form.getInputProps('bundleName')} disabled={loading} />
-                    <Checkbox.Group label="Repositories" key={form.key('repositories')} {...form.getInputProps('repositories')}>
-                        <Stack mt="xs">{repoOptions.map((repo) => <Checkbox key={repo.value} value={repo.value} label={repo.label} />)}</Stack>
-                    </Checkbox.Group>
-                    <Textarea
-                        label="Custom repositories"
-                        description="1行1件。URLのみ、または `id|label|url` 形式で入力"
-                        placeholder={'https://download.example.com/rhel/8/BaseOS/x86_64/os/\ncustom-rhel8-appstream|RHEL 8 AppStream|https://download.example.com/rhel/8/AppStream/x86_64/os/'}
-                        minRows={3}
-                        key={form.key('customRepositories')}
-                        {...form.getInputProps('customRepositories')}
+            <CarbonForm accent="rpm" onSubmit={form.onSubmit(onSubmit)}>
+                <CarbonSection label="取得対象">
+                    <CarbonTextarea
+                        label={<>Package <span className={carbonClasses.required}>必須</span></>}
+                        value={fv.packages}
+                        onChange={(val) => form.setFieldValue('packages', val)}
+                        placeholder={'bash\ncoreutils'}
+                        rows={4}
+                        disabled={loading}
+                        desc="rpm 名をスペースまたは改行区切りで入力"
+                        error={form.errors.packages as string | undefined}
+                    />
+                    <CarbonField
+                        label="Bundle name"
+                        optional
+                        icon={IconBox}
+                        value={fv.bundleName}
+                        onChange={(val) => form.setFieldValue('bundleName', val)}
+                        placeholder="rpm-offline"
                         disabled={loading}
                     />
-                    <Checkbox label="依存関係もダウンロード (--resolve --alldeps)" key={form.key('resolveDependencies')} {...form.getInputProps('resolveDependencies', { type: 'checkbox' })} />
-                </Stack>
-                </FormCard>
-            </form>
-            {error && <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">{error}</Alert>}
+                    <CarbonCheckbox
+                        checked={fv.resolveDependencies}
+                        onChange={(c) => form.setFieldValue('resolveDependencies', c)}
+                        label="依存関係もダウンロード (--resolve --alldeps)"
+                        disabled={loading}
+                    />
+                </CarbonSection>
+
+                <div style={{ borderTop: '1px solid var(--af-border)' }}>
+                    <CarbonSection label="リポジトリ">
+                        <Stack gap={10}>
+                            {repoOptions.map((repo) => (
+                                <CarbonCheckbox
+                                    key={repo.value}
+                                    checked={fv.repositories.includes(repo.value)}
+                                    onChange={() => toggleRepo(repo.value)}
+                                    label={repo.label}
+                                    disabled={loading}
+                                />
+                            ))}
+                        </Stack>
+                        <CarbonTextarea
+                            label="Custom repositories"
+                            optional
+                            small
+                            value={fv.customRepositories}
+                            onChange={(val) => form.setFieldValue('customRepositories', val)}
+                            placeholder={'https://download.example.com/rhel/8/BaseOS/x86_64/os/\ncustom-rhel8-appstream|RHEL 8 AppStream|https://download.example.com/rhel/8/AppStream/x86_64/os/'}
+                            rows={3}
+                            disabled={loading}
+                            desc="1行1件。URL のみ、または id|label|url 形式で入力"
+                            error={form.errors.customRepositories as string | undefined}
+                        />
+                    </CarbonSection>
+                </div>
+
+                <CarbonFooter hint="依存込みで収集して tar 化します">
+                    <CarbonSubmit loading={loading}>取得を開始</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
+            {error && (
+                <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
+            )}
 
             <ProgressModal
                 opened={opened}

--- a/src/app/rpm/download.tsx
+++ b/src/app/rpm/download.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { PipPackageCard } from '@/components/PipPackageCard';
 import { ProgressEvent, type RpmPackage } from '@/lib/progressBus';
-import { Alert, Button, Checkbox, Group, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput, Badge, Loader, Center } from '@mantine/core';
+import { Alert, Button, Checkbox, ScrollArea, Stack, Text, Textarea, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconCircleCheck, IconDownload, IconStackFront } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { IconAlertTriangle, IconArrowRight, IconDownload } from '@tabler/icons-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FormCard } from '@/components/FormCard';
+import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
 
 const repoOptions = [
     { value: 'centos-stream-9-baseos', label: 'CentOS Stream 9 BaseOS (official)' },
@@ -177,13 +178,34 @@ export function DownloadPane() {
         }
     };
 
-    const totals = useMemo(() => Object.values(perPackage).reduce((acc, item) => ({ received: acc.received + (item.received || 0), total: acc.total + (item.total || 0) }), { received: 0, total: 0 }), [perPackage]);
-    const overallPercent = totals.total > 0 ? Math.floor((totals.received / totals.total) * 100) : 0;
+    const totals = Object.values(perPackage).reduce<{ received: number; total: number }>((acc, item) => ({ received: acc.received + (item.received || 0), total: acc.total + (item.total || 0) }), { received: 0, total: 0 });
+    const indeterminate = status === 'starting' || status === 'running' || packages.length === 0;
+    const overallPercent = totals.total > 0 ? Math.floor((totals.received / totals.total) * 100) : (status === 'done' ? 100 : 0);
+    const state: 'running' | 'done' | 'error' = status === 'done' ? 'done' : status === 'error' ? 'error' : 'running';
+
+    const items: ProgressItem[] = packages.map((pkg, idx) => {
+        const info = perPackage[idx];
+        const raw = info?.status ?? 'waiting';
+        const pct = info?.total ? Math.floor(((info.received || 0) / info.total) * 100) : 0;
+        const st: ProgressItem['status'] = raw === 'done' ? 'done' : raw === 'downloading' ? 'running' : 'waiting';
+        return {
+            key: `${pkg.filename}-${idx}`,
+            label: pkg.name,
+            status: st,
+            percent: pct,
+            meta: st === 'done' ? '完了' : info?.total ? `${(info.total / 1_000_000).toFixed(1)}MB` : '待機',
+        };
+    });
+    const doneCount = items.filter((i) => i.status === 'done').length;
 
     return (
         <div>
-            <Alert variant="light" color="yellow" title="注意" radius="lg" my="xl">依存関係解決を有効にすると、対象パッケージが多くなるため時間がかかる場合があります。</Alert>
+            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">依存関係解決を有効にすると、対象パッケージが多くなるため時間がかかる場合があります。</Alert>
             <form onSubmit={form.onSubmit(onSubmit)}>
+                <FormCard
+                    hint={<Text className="af-mono" fz={12} c="var(--af-dim)">依存込みで収集して tar 化します</Text>}
+                    actions={<Button size="md" radius="md" color="rpm" type="submit" loading={loading} rightSection={<IconArrowRight size="1.05rem" />}>取得を開始</Button>}
+                >
                 <Stack>
                     <Textarea label="Package" description="rpm名をスペースまたは改行区切りで入力" minRows={4} autosize size="lg" radius="lg" placeholder="bash\ncoreutils" key={form.key('packages')} {...form.getInputProps('packages')} disabled={loading} />
                     <TextInput label="Bundle name" size="lg" radius="lg" key={form.key('bundleName')} {...form.getInputProps('bundleName')} disabled={loading} />
@@ -200,27 +222,48 @@ export function DownloadPane() {
                         disabled={loading}
                     />
                     <Checkbox label="依存関係もダウンロード (--resolve --alldeps)" key={form.key('resolveDependencies')} {...form.getInputProps('resolveDependencies', { type: 'checkbox' })} />
-                    <Space h="md" />
-                    <Button size="lg" radius="lg" type="submit" loading={loading}>Download</Button>
                 </Stack>
+                </FormCard>
             </form>
-            {error && <Alert color="red" radius="lg" title="エラー" my="lg" variant="light">{error}</Alert>}
+            {error && <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">{error}</Alert>}
 
-            <Modal opened={opened} onClose={handleCloseModal} centered radius="lg" size="lg" transitionProps={{ transition: 'pop' }} withCloseButton>
-                <Group justify="space-between"><Group gap="xs"><IconStackFront /><Text fw="bold" size="lg">ダウンロード進捗</Text></Group>{status === 'done' ? <Badge color="green" leftSection={<IconCircleCheck size="1em" />} radius="sm">done</Badge> : <Badge color={status === 'error' ? 'red' : 'gray'} leftSection={status === 'error' ? undefined : <Loader size="1em" color="white" />} radius="sm">{status}</Badge>}</Group>
-                {jobId && <Text size="xs" c="dimmed">jobId: {jobId}</Text>}
-                <Stack gap={10} py="xs"><Group justify="space-between"><Text fw="bold">全体の進捗</Text><Text>{overallPercent}%</Text></Group><Progress value={overallPercent} size="lg" radius="xl" /><Text size="xs" c="dimmed">{(totals.received / 1_000_000).toFixed(2)}MB / {(totals.total / 1_000_000).toFixed(2)}MB</Text></Stack>
-                <Stack gap={8}>
-                    <Text size="sm" fw={600}>現在のステージ: {currentStage}</Text>
-                    <ScrollArea h={150} type="auto" offsetScrollbars>
-                        <Stack gap={2}>
-                            {logs.length === 0 ? <Text size="xs" c="dimmed">ログ待機中...</Text> : logs.map((line, idx) => <Text key={`${line}-${idx}`} size="xs" ff="monospace">{line}</Text>)}
-                        </Stack>
-                    </ScrollArea>
-                </Stack>
-                <ScrollArea h={260}><Stack gap="sm">{packages.length === 0 && (status === 'starting' || status === 'running') ? <Center h={120}><Loader /></Center> : packages.map((pkg, idx) => <PipPackageCard key={`${pkg.filename}-${idx}`} index={idx} name={pkg.name} version={pkg.version} filename={`${pkg.filename}${pkg.repositoryFolder ? ` • ${pkg.repositoryFolder}` : ''}`} received={perPackage[idx]?.received ?? 0} total={perPackage[idx]?.total} status={perPackage[idx]?.status ?? 'waiting'} />)}</Stack></ScrollArea>
-                <Button leftSection={<IconDownload size="1em" />} fullWidth radius="lg" mt="md" color="dark" disabled={!jobId || status !== 'done'} component="a" href={jobId ? `/api/build/download?jobId=${jobId}` : '#'} target="_blank">ダウンロード</Button>
-            </Modal>
+            <ProgressModal
+                opened={opened}
+                onClose={handleCloseModal}
+                accent="rpm"
+                title={state === 'done' ? '取得完了' : state === 'error' ? '取得に失敗' : '取得中'}
+                subtitle={`stage: ${currentStage} · ${packages.length} packages`}
+                overallPercent={indeterminate ? undefined : overallPercent}
+                state={state}
+                stats={[
+                    { value: doneCount, unit: `/${packages.length}`, label: '完了 / 全体', accent: state === 'done' },
+                    { value: (totals.received / 1_000_000).toFixed(0), unit: ' MB', label: '取得サイズ' },
+                    { value: packages.length, label: 'パッケージ' },
+                ]}
+                extra={
+                    <>
+                        <Text className="af-mono" fz={10} mb={6} style={{ letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--af-dim)' }}>dnf ログ · {currentStage}</Text>
+                        <ScrollArea.Autosize mah={120}>
+                            <Stack gap={2}>
+                                {logs.length === 0 ? <Text size="xs" c="dimmed">ログ待機中...</Text> : logs.map((line, idx) => <Text key={`${line}-${idx}`} size="xs" ff="monospace" c="var(--af-muted)">{line}</Text>)}
+                            </Stack>
+                        </ScrollArea.Autosize>
+                    </>
+                }
+                items={items}
+                banner={state === 'done' ? <ProgressBanner tone="success" title={`${packages.length} パッケージを取得しました`} detail={`${(totals.received / 1_000_000).toFixed(1)} MB`} /> : undefined}
+                footer={state === 'done' ? (
+                    <>
+                        <Button variant="default" radius="md" onClick={handleCloseModal}>閉じる</Button>
+                        <Button color="success" radius="md" leftSection={<IconDownload size="1rem" />} component="a" href={jobId ? `/api/build/download?jobId=${jobId}` : '#'} target="_blank" disabled={!jobId}>アーカイブをダウンロード</Button>
+                    </>
+                ) : (
+                    <>
+                        <Text className="af-mono" fz={12.5} c="var(--af-muted)">{indeterminate ? '解決しています…' : `${doneCount} / ${packages.length}`}</Text>
+                        <Button variant="default" radius="md" onClick={handleCloseModal}>キャンセル</Button>
+                    </>
+                )}
+            />
         </div>
     );
 }

--- a/src/app/rpm/page.tsx
+++ b/src/app/rpm/page.tsx
@@ -60,8 +60,8 @@ export default function RpmPage() {
                     <Tabs.Tab value="upload" leftSection={<IconUpload size="1em" />} disabled={!uploadEnabled}>アップロード</Tabs.Tab>
                 </Tabs.List>
 
-                <Tabs.Panel value="download"><DownloadPane /></Tabs.Panel>
-                {uploadEnabled && <Tabs.Panel value="upload"><UploadPane env={env} /></Tabs.Panel>}
+                <Tabs.Panel value="download" py="lg"><DownloadPane /></Tabs.Panel>
+                {uploadEnabled && <Tabs.Panel value="upload" py="lg"><UploadPane env={env} /></Tabs.Panel>}
             </Tabs>
             <Space h="xl" />
         </div>

--- a/src/app/rpm/page.tsx
+++ b/src/app/rpm/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Group, Space, Tabs, Text, ThemeIcon, Title } from '@mantine/core';
-import { IconBox, IconDownload, IconUpload } from '@tabler/icons-react';
+import { Space, Tabs } from '@mantine/core';
+import { IconDownload, IconUpload } from '@tabler/icons-react';
 import { DownloadPane } from './download';
 import { UploadPane } from './upload';
 import { useEffect, useState } from 'react';
 import { getEnvironmentVar } from '@/components/actions';
+import { PageHeader } from '@/components/PageHeader';
 
 type RpmEnv = {
     RPM_UPLOAD: string;
@@ -46,19 +47,14 @@ export default function RpmPage() {
 
     return (
         <div>
-            <Group justify="space-between">
-                <Title>rpm package</Title>
-                <ThemeIcon variant="transparent" size={60} color="yellow">
-                    <IconBox style={{ width: '70%', height: '70%' }} stroke={1.3} />
-                </ThemeIcon>
-            </Group>
-            <Text c="dimmed">
-                公式リポジトリや EPEL から依存関係を含めた rpm をダウンロードし、任意の RPM リポジトリにアップロードできます。
-            </Text>
+            <PageHeader
+                manager="rpm"
+                description="公式リポジトリ / EPEL から依存込みで収集し、任意の RPM リポジトリへアップロード。"
+            />
 
-            <Space h="xl" />
+            <Space h="md" />
 
-            <Tabs variant="pills" radius="lg" defaultValue="download">
+            <Tabs variant="pills" color="rpm" radius="xl" defaultValue="download">
                 <Tabs.List>
                     <Tabs.Tab value="download" leftSection={<IconDownload size="1em" />}>ダウンロード</Tabs.Tab>
                     <Tabs.Tab value="upload" leftSection={<IconUpload size="1em" />} disabled={!uploadEnabled}>アップロード</Tabs.Tab>

--- a/src/app/rpm/upload.tsx
+++ b/src/app/rpm/upload.tsx
@@ -9,7 +9,7 @@ import { Accordion, Alert, Button, Checkbox, Group, PasswordInput, Radio, Space,
 import { Dropzone } from '@mantine/dropzone';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconCloudCog, IconCloudUpload, IconDownload, IconX } from '@tabler/icons-react';
+import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconX } from '@tabler/icons-react';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -182,7 +182,7 @@ export function UploadPane({ env }: { env: EnvProps }) {
 
     return (
         <div>
-            <Alert variant="light" color="yellow" title="注意" radius="lg" my="xl">アップロード先RPMリポジトリは URL/認証方式が実装により異なります。PUT/POST を切り替えて利用してください。</Alert>
+            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">アップロード先RPMリポジトリは URL/認証方式が実装により異なります。PUT/POST を切り替えて利用してください。</Alert>
             <Stack>
                 <Dropzone
                     accept={['.rpm', 'application/x-rpm', 'application/x-redhat-package-manager', 'application/octet-stream']}
@@ -209,11 +209,11 @@ export function UploadPane({ env }: { env: EnvProps }) {
                 </Stack></Accordion.Panel></Accordion.Item></Accordion>
 
                 <Space h="md" />
-                <Button size="lg" radius="lg" onClick={startUpload} loading={loading}>Upload</Button>
-                {error && <Alert color="red" radius="lg" title="エラー" my="lg" variant="light">{error}</Alert>}
+                <Button size="md" radius="md" color="rpm" onClick={startUpload} loading={loading} leftSection={<IconCloudUpload size="1.1rem" />}>アップロード実行</Button>
+                {error && <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">{error}</Alert>}
             </Stack>
 
-            <PackageUploadModal opened={opened} onClose={handleClose} jobId={jobId} files={form.getValues().files} perFile={perFileSnap} status={loading ? 'running' : error ? 'error' : jobId ? 'done' : 'idle'} />
+            <PackageUploadModal accent="rpm" opened={opened} onClose={handleClose} jobId={jobId} files={form.getValues().files} perFile={perFileSnap} status={loading ? 'running' : error ? 'error' : jobId ? 'done' : 'idle'} />
         </div>
     );
 }

--- a/src/app/rpm/upload.tsx
+++ b/src/app/rpm/upload.tsx
@@ -5,11 +5,11 @@ import { FileItem } from '@/components/Upload/FileItem';
 import { ProgressEvent } from '@/lib/progressBus';
 import { useRetryableEventSource } from '@/lib/useRetryableEventSource';
 import { buildAuthHeaders } from '@/lib/authHeaders';
-import { Accordion, Alert, Button, Checkbox, Group, PasswordInput, Radio, Space, Stack, Text, TextInput } from '@mantine/core';
 import { Dropzone } from '@mantine/dropzone';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconAlertTriangle, IconCloudCog, IconCloudUpload, IconDownload, IconX } from '@tabler/icons-react';
+import { IconAlertCircle, IconCloudUpload, IconKey, IconServer, IconX } from '@tabler/icons-react';
+import { CarbonCard, CarbonSection, CarbonField, CarbonPassword, CarbonSegmented, CarbonCheckbox, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonList, carbonClasses, carbonDropzoneClasses } from '@/components/CarbonForm';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -70,7 +70,7 @@ export function UploadPane({ env }: { env: EnvProps }) {
     }, []);
 
     const form = useForm<FormValues>({
-        mode: 'uncontrolled',
+        mode: 'controlled',
         initialValues: {
             files: [],
             repositoryUrl: env.RPM_UPLOAD_REPOSITORY_URL || '',
@@ -180,38 +180,77 @@ export function UploadPane({ env }: { env: EnvProps }) {
         if (current) fetch(`/api/build/delete?jobId=${current}`, { method: 'POST' }).catch(() => undefined);
     }, [jobId, close, resetStreams]);
 
+    const files = form.getValues().files;
+    const completed = Object.values(perFileSnap).filter((s) => s?.status === 'published' || s?.status === 'uploaded').length;
+
     return (
         <div>
-            <Alert variant="light" color="warning" icon={<IconAlertTriangle size="1.1em" />} radius="md" mb="lg">アップロード先RPMリポジトリは URL/認証方式が実装により異なります。PUT/POST を切り替えて利用してください。</Alert>
-            <Stack>
-                <Dropzone
-                    accept={['.rpm', 'application/x-rpm', 'application/x-redhat-package-manager', 'application/octet-stream']}
-                    onDrop={(files) => form.setFieldValue('files', [...form.getValues().files, ...files])}
-                    onReject={() => setError('rpmファイルのみアップロードできます')}
-                    disabled={loading}
+            <CarbonCard accent="rpm">
+                <CarbonAuthPanel
+                    icon={IconServer}
+                    title="アップロード先"
+                    sub={`${form.getValues().repositoryUrl?.trim() || 'レジストリ未設定'} · ${String(form.getValues().method || 'put').toUpperCase()} · ${form.getValues().token ? 'トークン認証' : (form.getValues().username ? 'Basic 認証' : '認証なし')}`}
+                    configured={Boolean(form.getValues().repositoryUrl?.trim())}
+                    defaultOpen
                 >
-                    <Group justify="center" gap="xl" mih={120} style={{ pointerEvents: 'none' }}>
-                        <Dropzone.Accept><IconDownload size={52} color="var(--mantine-color-blue-6)" stroke={1.5} /></Dropzone.Accept>
-                        <Dropzone.Reject><IconX size={52} color="var(--mantine-color-red-6)" stroke={1.5} /></Dropzone.Reject>
-                        <Dropzone.Idle><IconCloudUpload size={52} color="var(--mantine-color-dimmed)" stroke={1.5} /></Dropzone.Idle>
-                        <div><Text size="xl" inline>ここにファイルをドロップするかクリックして選択</Text><Text size="sm" c="dimmed" inline mt={7}>複数rpmファイルをまとめてアップロードできます</Text></div>
-                    </Group>
-                </Dropzone>
-                <Stack gap="xs">{form.getValues().files.map((file, index) => { const total = perFileSnap[index]?.total ?? file.size; const received = perFileSnap[index]?.received ?? 0; const percent = total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0; return <FileItem key={`${file.name}-${index}`} file={file} status={perFileSnap[index]?.status ?? 'waiting'} percent={percent} onDelete={(target) => form.setFieldValue('files', form.getValues().files.filter((item) => item !== target))} loading={loading} />; })}</Stack>
+                    <CarbonField label="Repository URL" icon={IconServer} value={form.getValues().repositoryUrl} onChange={(v) => form.setFieldValue('repositoryUrl', v)} placeholder="https://nexus.example.com/repository/rpm-hosted/" disabled={loading} />
+                    <CarbonSegmented
+                        label="HTTP Method"
+                        options={[{ value: 'put', label: 'PUT' }, { value: 'post', label: 'POST' }]}
+                        value={form.getValues().method}
+                        onChange={(v) => form.setFieldValue('method', v as 'put' | 'post')}
+                        disabled={loading}
+                    />
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                        <CarbonField label="Username" optional small value={form.getValues().username} onChange={(v) => form.setFieldValue('username', v)} placeholder="username" disabled={loading} />
+                        <CarbonPassword label="Password" optional value={form.getValues().password} onChange={(v) => form.setFieldValue('password', v)} placeholder="password" disabled={loading} />
+                    </div>
+                    <CarbonPassword label="Bearer Token" optional icon={IconKey} value={form.getValues().token} onChange={(v) => form.setFieldValue('token', v)} placeholder="token" disabled={loading} />
+                    <CarbonCheckbox checked={form.getValues().ignoreTlsVerify} onChange={(c) => form.setFieldValue('ignoreTlsVerify', c)} label="証明書の検証を無視する (curl --insecure)" disabled={loading} />
+                </CarbonAuthPanel>
 
-                <Accordion radius="md" variant="contained"><Accordion.Item value="registry"><Accordion.Control icon={<IconCloudCog size={16} />}>アップロード設定</Accordion.Control><Accordion.Panel><Stack>
-                    <TextInput label="Repository URL" placeholder="https://nexus.example.com/repository/rpm-hosted/" key={form.key('repositoryUrl')} {...form.getInputProps('repositoryUrl')} disabled={loading} />
-                    <Radio.Group label="HTTP Method" key={form.key('method')} {...form.getInputProps('method')}><Group mt="xs"><Radio value="put" label="PUT" /><Radio value="post" label="POST" /></Group></Radio.Group>
-                    <TextInput label="Username" key={form.key('username')} {...form.getInputProps('username')} disabled={loading} />
-                    <PasswordInput label="Password" key={form.key('password')} {...form.getInputProps('password')} disabled={loading} />
-                    <PasswordInput label="Bearer Token" key={form.key('token')} {...form.getInputProps('token')} disabled={loading} />
-                    <Checkbox label="証明書の検証を無視する (curl --insecure)" key={form.key('ignoreTlsVerify')} {...form.getInputProps('ignoreTlsVerify', { type: 'checkbox' })} disabled={loading} />
-                </Stack></Accordion.Panel></Accordion.Item></Accordion>
+                <CarbonSection>
+                    <Dropzone
+                        accept={['.rpm', 'application/x-rpm', 'application/x-redhat-package-manager', 'application/octet-stream']}
+                        onDrop={(dropped) => form.setFieldValue('files', [...form.getValues().files, ...dropped])}
+                        onReject={() => setError('rpmファイルのみアップロードできます')}
+                        disabled={loading}
+                        p="xl"
+                        className={carbonDropzoneClasses.root}
+                    >
+                        <div style={{ pointerEvents: 'none', textAlign: 'center' }}>
+                            <span className={carbonDropzoneClasses.icon}>
+                                <Dropzone.Idle><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Idle>
+                                <Dropzone.Accept><IconCloudUpload size={26} stroke={1.7} /></Dropzone.Accept>
+                                <Dropzone.Reject><IconX size={26} stroke={1.7} /></Dropzone.Reject>
+                            </span>
+                            <div className={carbonDropzoneClasses.title}>.rpm をドロップ</div>
+                            <div className={carbonDropzoneClasses.sub}>または クリックして選択 ・ 複数可</div>
+                        </div>
+                    </Dropzone>
 
-                <Space h="md" />
-                <Button size="md" radius="md" color="rpm" onClick={startUpload} loading={loading} leftSection={<IconCloudUpload size="1.1rem" />}>アップロード実行</Button>
-                {error && <Alert color="npm" radius="md" title="エラー" my="lg" variant="light">{error}</Alert>}
-            </Stack>
+                    {files.length > 0 && (
+                        <CarbonList title={`キュー · ${files.length} ファイル`} right={`${completed} / ${files.length} 完了`}>
+                            {files.map((file, index) => {
+                                const total = perFileSnap[index]?.total ?? file.size;
+                                const received = perFileSnap[index]?.received ?? 0;
+                                const percent = total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0;
+                                return <FileItem key={`${file.name}-${index}`} file={file} status={perFileSnap[index]?.status ?? 'waiting'} percent={percent} onDelete={(target) => form.setFieldValue('files', form.getValues().files.filter((item) => item !== target))} loading={loading} />;
+                            })}
+                        </CarbonList>
+                    )}
+                </CarbonSection>
+
+                <CarbonFooter hint={files.length ? `${files.length} ファイルを ${String(form.getValues().method || 'put').toUpperCase()} で送信します` : '.rpm を追加してください'}>
+                    <CarbonSubmit type="button" onClick={startUpload} loading={loading} icon={IconCloudUpload}>アップロード実行</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonCard>
+
+            {error && (
+                <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>
+                    <IconAlertCircle size={14} stroke={2} />{error}
+                </div>
+            )}
 
             <PackageUploadModal accent="rpm" opened={opened} onClose={handleClose} jobId={jobId} files={form.getValues().files} perFile={perFileSnap} status={loading ? 'running' : error ? 'error' : jobId ? 'done' : 'idle'} />
         </div>

--- a/src/components/AccentTile/index.tsx
+++ b/src/components/AccentTile/index.tsx
@@ -1,0 +1,49 @@
+import { type ManagerId } from "../managers";
+
+const SIZE_MAP = {
+    sm: { box: 24, radius: 6, font: 9, glow: 10 },
+    md: { box: 30, radius: 8, font: 11, glow: 16 },
+    lg: { box: 46, radius: 12, font: 13, glow: 20 },
+    xl: { box: 54, radius: 14, font: 16, glow: 26 },
+} as const;
+
+/**
+ * Glowing accent tile with a short code (DKR / NPM / …).
+ * The signature visual element of the Carbon design.
+ */
+export function AccentTile({
+    color,
+    code,
+    size = "md",
+    glow = true,
+}: {
+    color: ManagerId | "docker";
+    code: string;
+    size?: keyof typeof SIZE_MAP;
+    glow?: boolean;
+}) {
+    const s = SIZE_MAP[size];
+    const accent = `var(--af-${color})`;
+    return (
+        <span
+            style={{
+                width: s.box,
+                height: s.box,
+                borderRadius: s.radius,
+                background: accent,
+                boxShadow: glow ? `0 0 ${s.glow}px color-mix(in oklch, ${accent} 45%, transparent)` : undefined,
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontFamily: "var(--mantine-font-family-monospace)",
+                fontWeight: 600,
+                fontSize: s.font,
+                color: "#070A10",
+                flex: "none",
+                letterSpacing: "0.02em",
+            }}
+        >
+            {code}
+        </span>
+    );
+}

--- a/src/components/AppTitle/index.tsx
+++ b/src/components/AppTitle/index.tsx
@@ -1,13 +1,13 @@
 import { Group, Text } from "@mantine/core";
+import Image from "next/image";
 import Link from "next/link";
-import { AccentTile } from "../AccentTile";
 import classes from "./styles.module.css";
 
 export const AppTitle = () => {
     return (
         <Link href="/" className={classes.title}>
             <Group gap="xs" wrap="nowrap">
-                <AccentTile color="docker" code="AF" size="md" />
+                <Image alt="icon" width={34} height={34} src="/icon.png" />
                 <Text
                     fw={600}
                     fz={15}

--- a/src/components/AppTitle/index.tsx
+++ b/src/components/AppTitle/index.tsx
@@ -1,30 +1,22 @@
-import { Group, Anchor, Title } from "@mantine/core";
-import Image from "next/image";
+import { Group, Text } from "@mantine/core";
+import Link from "next/link";
+import { AccentTile } from "../AccentTile";
 import classes from "./styles.module.css";
 
 export const AppTitle = () => {
     return (
-        <Group
-            gap={0}
-        >
-            <Image
-                alt="icon"
-                width={50}
-                height={50}
-                src="/icon.png"
-            />
-            <Anchor
-                variant="text"
-                td="none"
-                href="/"
-                className={classes.title}
-            >
-                <Title
-                    order={3}
+        <Link href="/" className={classes.title}>
+            <Group gap="xs" wrap="nowrap">
+                <AccentTile color="docker" code="AF" size="md" />
+                <Text
+                    fw={600}
+                    fz={15}
+                    style={{ letterSpacing: "-0.01em" }}
+                    visibleFrom="xs"
                 >
                     Artifact Fetcher
-                </Title>
-            </Anchor>
-        </Group>
+                </Text>
+            </Group>
+        </Link>
     );
 }

--- a/src/components/AppTitle/styles.module.css
+++ b/src/components/AppTitle/styles.module.css
@@ -1,3 +1,5 @@
 .title {
-    color: var(--mantine-color-default-color);
+    color: var(--af-text);
+    text-decoration: none;
+    cursor: pointer;
 }

--- a/src/components/CarbonForm/index.tsx
+++ b/src/components/CarbonForm/index.tsx
@@ -36,6 +36,35 @@ export function CarbonForm({
     );
 }
 
+/** bordered card with accent context (no form wrapper) */
+export function CarbonCard({ accent, children }: { accent: ManagerId; children: ReactNode }) {
+    return (
+        <div className={classes.card} style={accentStyle(accent)}>
+            {children}
+        </div>
+    );
+}
+
+/** styled file-list container with a header */
+export function CarbonList({ title, right, children }: { title: ReactNode; right?: ReactNode; children: ReactNode }) {
+    return (
+        <div className={classes.list}>
+            <div className={classes.listHeader}>
+                <span className={classes.listTitle}>{title}</span>
+                {right && <span className={classes.listMeta}>{right}</span>}
+            </div>
+            <div className={classes.listBody}>{children}</div>
+        </div>
+    );
+}
+
+export const carbonDropzoneClasses = {
+    root: classes.dropzone,
+    icon: classes.dropzoneIcon,
+    title: classes.dropzoneTitle,
+    sub: classes.dropzoneSub,
+};
+
 /** Expandable 接続/設定 panel */
 export function CarbonAuthPanel({
     icon: Icon,
@@ -268,11 +297,11 @@ export function CarbonFooter({ hint, children }: { hint?: ReactNode; children: R
     );
 }
 
-export function CarbonSubmit({ loading, children }: { loading?: boolean; children: ReactNode }) {
+export function CarbonSubmit({ loading, icon: Icon = IconArrowRight, onClick, type = "submit", children }: { loading?: boolean; icon?: TablerIcon; onClick?: () => void; type?: "submit" | "button"; children: ReactNode }) {
     return (
-        <button type="submit" className={classes.btnPrimary} disabled={loading}>
+        <button type={type} className={classes.btnPrimary} disabled={loading} onClick={onClick}>
             {children}
-            <IconArrowRight size={17} stroke={2} />
+            <Icon size={17} stroke={2} />
         </button>
     );
 }

--- a/src/components/CarbonForm/index.tsx
+++ b/src/components/CarbonForm/index.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { CSSProperties, ReactNode, useState } from "react";
+import {
+    IconAlertCircle,
+    IconArrowRight,
+    IconChevronDown,
+    IconCheck,
+    IconEye,
+    IconEyeOff,
+    type TablerIcon,
+} from "@tabler/icons-react";
+import { type ManagerId } from "../managers";
+import classes from "./styles.module.css";
+
+function accentStyle(accent: ManagerId): CSSProperties {
+    return { ["--accent" as string]: `var(--af-${accent})` };
+}
+
+/** form + bordered card with accent context */
+export function CarbonForm({
+    accent,
+    onSubmit,
+    children,
+}: {
+    accent: ManagerId;
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    children: ReactNode;
+}) {
+    return (
+        <form onSubmit={onSubmit}>
+            <div className={classes.card} style={accentStyle(accent)}>
+                {children}
+            </div>
+        </form>
+    );
+}
+
+/** Expandable 接続/設定 panel */
+export function CarbonAuthPanel({
+    icon: Icon,
+    title,
+    sub,
+    configured,
+    defaultOpen = true,
+    children,
+}: {
+    icon: TablerIcon;
+    title: string;
+    sub: string;
+    configured?: boolean;
+    defaultOpen?: boolean;
+    children: ReactNode;
+}) {
+    const [open, setOpen] = useState(defaultOpen);
+    return (
+        <div>
+            <button type="button" className={classes.authHeader} onClick={() => setOpen((o) => !o)} aria-expanded={open}>
+                <span className={classes.fieldIcon}><Icon size={18} stroke={1.7} /></span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <div className={classes.authHeaderTitle}>{title}</div>
+                    <div className={classes.authSub}>{sub}</div>
+                </div>
+                <span className={`${classes.chip} ${configured ? classes.chipOk : classes.chipMuted}`}>
+                    {configured ? "設定済" : "任意"}
+                </span>
+                <span className={`${classes.chevron} ${open ? classes.chevronOpen : ""}`}>
+                    <IconChevronDown size={18} stroke={1.7} />
+                </span>
+            </button>
+            {open && <div className={classes.authBody}>{children}</div>}
+        </div>
+    );
+}
+
+export function CarbonSection({ label, children }: { label?: string; children: ReactNode }) {
+    return (
+        <div className={classes.section}>
+            {label && <div className={classes.eyebrow}>{label}</div>}
+            {children}
+        </div>
+    );
+}
+
+function FieldLabel({ label, required, optional, small }: { label?: ReactNode; required?: boolean; optional?: boolean; small?: boolean }) {
+    if (!label) return null;
+    return (
+        <label className={`${classes.label} ${small ? classes.labelSm : ""}`}>
+            {label}
+            {required && <span className={classes.required}>必須</span>}
+            {optional && <span className={classes.optional}>任意</span>}
+        </label>
+    );
+}
+
+/** single-line text field */
+export function CarbonField({
+    label,
+    required,
+    optional,
+    small,
+    accent,
+    error,
+    icon: Icon,
+    rightSection,
+    type = "text",
+    value,
+    onChange,
+    placeholder,
+    disabled,
+    desc,
+}: {
+    label?: ReactNode;
+    required?: boolean;
+    optional?: boolean;
+    small?: boolean;
+    accent?: boolean;
+    error?: string;
+    icon?: TablerIcon;
+    rightSection?: ReactNode;
+    type?: string;
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    desc?: string;
+}) {
+    return (
+        <div>
+            <FieldLabel label={label} required={required} optional={optional} small={small} />
+            <div className={`${classes.fieldBox} ${accent ? classes.accentBox : ""} ${error ? classes.errorBox : ""}`}>
+                {Icon && <span className={classes.fieldIcon}><Icon size={accent ? 18 : 16} stroke={1.7} /></span>}
+                <input
+                    className={`${classes.input} ${accent ? classes.inputLg : ""}`}
+                    type={type}
+                    value={value}
+                    onChange={(e) => onChange(e.currentTarget.value)}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                />
+                {rightSection}
+            </div>
+            {error ? <div className={classes.errorText}><IconAlertCircle size={13} stroke={2} />{error}</div> : desc ? <div className={classes.desc}>{desc}</div> : null}
+        </div>
+    );
+}
+
+/** password field with show/hide */
+export function CarbonPassword({
+    label, optional, value, onChange, placeholder, disabled, icon: Icon,
+}: {
+    label?: ReactNode; optional?: boolean; value: string; onChange: (v: string) => void; placeholder?: string; disabled?: boolean; icon?: TablerIcon;
+}) {
+    const [show, setShow] = useState(false);
+    return (
+        <CarbonField
+            label={label}
+            optional={optional}
+            icon={Icon}
+            type={show ? "text" : "password"}
+            value={value}
+            onChange={onChange}
+            placeholder={placeholder}
+            disabled={disabled}
+            rightSection={
+                <button type="button" className={classes.iconBtn} onClick={() => setShow((s) => !s)} aria-label={show ? "隠す" : "表示"}>
+                    {show ? <IconEyeOff size={16} stroke={1.6} /> : <IconEye size={16} stroke={1.6} />}
+                </button>
+            }
+        />
+    );
+}
+
+/** multi-line field */
+export function CarbonTextarea({
+    label, required, optional, small, value, onChange, placeholder, disabled, rows = 5, desc, error,
+}: {
+    label?: ReactNode; required?: boolean; optional?: boolean; small?: boolean; value: string; onChange: (v: string) => void; placeholder?: string; disabled?: boolean; rows?: number; desc?: string; error?: string;
+}) {
+    return (
+        <div>
+            <FieldLabel label={label} required={required} optional={optional} small={small} />
+            <textarea
+                className={classes.textarea}
+                value={value}
+                onChange={(e) => onChange(e.currentTarget.value)}
+                placeholder={placeholder}
+                disabled={disabled}
+                rows={rows}
+                style={error ? { borderColor: "color-mix(in oklch, var(--af-error) 65%, transparent)" } : undefined}
+            />
+            {error ? <div className={classes.errorText}><IconAlertCircle size={13} stroke={2} />{error}</div> : desc ? <div className={classes.desc}>{desc}</div> : null}
+        </div>
+    );
+}
+
+export function CarbonSegmented({
+    label, options, value, onChange, disabled,
+}: {
+    label?: ReactNode; options: { value: string; label: string }[]; value: string; onChange: (v: string) => void; disabled?: boolean;
+}) {
+    return (
+        <div>
+            <FieldLabel label={label} />
+            <div className={classes.segmented}>
+                {options.map((o) => (
+                    <button key={o.value} type="button" className={`${classes.segItem} ${value === o.value ? classes.segItemActive : ""}`} onClick={() => onChange(o.value)} disabled={disabled}>
+                        {o.label}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export function CarbonToggle({
+    checked, onChange, label, badge,
+}: {
+    checked: boolean; onChange: (v: boolean) => void; label: string; badge?: string;
+}) {
+    return (
+        <div
+            className={classes.toggleRow}
+            role="switch"
+            aria-checked={checked}
+            tabIndex={0}
+            onClick={() => onChange(!checked)}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(!checked); } }}
+        >
+            <span className={`${classes.toggle} ${checked ? classes.toggleOn : ""}`}>
+                <span className={`${classes.knob} ${checked ? classes.knobOn : ""}`} />
+            </span>
+            <span className={classes.toggleLabel}>{label}</span>
+            {badge && <span className={classes.warnBadge}>{badge}</span>}
+        </div>
+    );
+}
+
+export function CarbonCheckbox({
+    checked, onChange, label, disabled,
+}: {
+    checked: boolean; onChange: (v: boolean) => void; label: ReactNode; disabled?: boolean;
+}) {
+    return (
+        <div
+            className={classes.checkRow}
+            role="checkbox"
+            aria-checked={checked}
+            tabIndex={0}
+            onClick={() => !disabled && onChange(!checked)}
+            onKeyDown={(e) => { if (!disabled && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); onChange(!checked); } }}
+            style={disabled ? { opacity: 0.5, cursor: "default" } : undefined}
+        >
+            <span className={`${classes.checkbox} ${checked ? classes.checkboxOn : ""}`}>
+                {checked && <IconCheck size={13} stroke={3} />}
+            </span>
+            <span className={classes.toggleLabel}>{label}</span>
+        </div>
+    );
+}
+
+export function CarbonFooter({ hint, children }: { hint?: ReactNode; children: ReactNode }) {
+    return (
+        <div className={classes.footer}>
+            <span className={classes.hint}>{hint}</span>
+            <div className={classes.actions}>{children}</div>
+        </div>
+    );
+}
+
+export function CarbonSubmit({ loading, children }: { loading?: boolean; children: ReactNode }) {
+    return (
+        <button type="submit" className={classes.btnPrimary} disabled={loading}>
+            {children}
+            <IconArrowRight size={17} stroke={2} />
+        </button>
+    );
+}
+
+export function CarbonGhostButton({ onClick, children }: { onClick?: () => void; children: ReactNode }) {
+    return (
+        <button type="button" className={classes.btnGhost} onClick={onClick}>
+            {children}
+        </button>
+    );
+}
+
+export const carbonClasses = classes;

--- a/src/components/CarbonForm/styles.module.css
+++ b/src/components/CarbonForm/styles.module.css
@@ -324,6 +324,70 @@
     border-color: transparent;
 }
 
+/* dropzone */
+.dropzone {
+    border: 1.5px dashed color-mix(in oklch, var(--accent) 45%, transparent) !important;
+    background: color-mix(in oklch, var(--accent) 4%, transparent) !important;
+    border-radius: var(--mantine-radius-lg) !important;
+}
+.dropzone:hover {
+    background: color-mix(in oklch, var(--accent) 8%, transparent) !important;
+}
+.dropzoneIcon {
+    width: 52px;
+    height: 52px;
+    border-radius: 14px;
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 14px;
+}
+.dropzoneTitle {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--af-text);
+    margin-bottom: 6px;
+}
+.dropzoneSub {
+    font-size: 13px;
+    color: var(--af-muted);
+}
+
+/* file list */
+.list {
+    background: var(--af-surface);
+    border: 1px solid var(--af-border);
+    border-radius: var(--mantine-radius-lg);
+    overflow: hidden;
+}
+.listHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 13px 18px;
+    border-bottom: 1px solid var(--af-border);
+}
+.listTitle {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--af-dim);
+}
+.listMeta {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11.5px;
+    color: var(--af-muted);
+}
+.listBody {
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
 /* footer */
 .footer {
     display: flex;

--- a/src/components/CarbonForm/styles.module.css
+++ b/src/components/CarbonForm/styles.module.css
@@ -1,0 +1,387 @@
+/* Shared Carbon form kit — generalized from the Docker download design.
+   Accent is parametrized via the --accent CSS variable set on .card. */
+
+.card {
+    background: var(--af-surface);
+    border: 1px solid var(--af-border);
+    border-radius: 16px;
+    overflow: hidden;
+}
+
+/* ---- auth / settings panel ---- */
+.authHeader {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 24px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-bottom: 1px solid var(--af-border);
+    cursor: pointer;
+    text-align: left;
+    color: var(--af-text);
+}
+.authHeaderTitle {
+    font-size: 14px;
+    font-weight: 600;
+}
+.authSub {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    color: var(--af-dim);
+    margin-top: 2px;
+}
+.chip {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    border-radius: 6px;
+    padding: 4px 9px;
+    line-height: 1;
+    flex: none;
+}
+.chipOk {
+    color: var(--af-success);
+    background: color-mix(in oklch, var(--af-success) 12%, transparent);
+}
+.chipMuted {
+    color: var(--af-dim);
+    background: var(--af-raised);
+}
+.chevron {
+    color: var(--af-dim);
+    display: inline-flex;
+    transition: transform 160ms ease;
+    flex: none;
+}
+.chevronOpen {
+    transform: rotate(180deg);
+}
+.authBody {
+    padding: 4px 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    background: var(--af-bg);
+    border-bottom: 1px solid var(--af-border);
+}
+
+/* ---- section ---- */
+.section {
+    padding: 26px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+.eyebrow {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--af-dim);
+}
+
+/* ---- fields ---- */
+.label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--af-text);
+    margin-bottom: 7px;
+}
+.labelSm {
+    font-size: 12px;
+    color: var(--af-muted);
+}
+.desc {
+    font-size: 11.5px;
+    color: var(--af-dim);
+    margin-top: 6px;
+}
+.required {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    color: var(--accent);
+    background: color-mix(in oklch, var(--accent) 14%, transparent);
+    border-radius: 5px;
+    padding: 2px 7px;
+    line-height: 1;
+}
+.optional {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    color: var(--af-dim);
+    background: var(--af-raised);
+    border-radius: 5px;
+    padding: 2px 7px;
+    line-height: 1;
+}
+
+.fieldBox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--af-raised);
+    border: 1px solid var(--af-border-strong);
+    border-radius: 10px;
+    padding: 0 12px;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.fieldBox:focus-within {
+    border-color: color-mix(in oklch, var(--accent) 55%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 12%, transparent);
+}
+.fieldIcon {
+    color: var(--af-dim);
+    display: inline-flex;
+    flex: none;
+}
+.input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--af-text);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 14px;
+    padding: 12px 0;
+}
+.input::placeholder {
+    color: var(--af-dim);
+}
+.inputLg {
+    font-size: 15px;
+    padding: 14px 0;
+}
+.iconBtn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--af-dim);
+    display: inline-flex;
+    padding: 0;
+}
+.iconBtn:hover {
+    color: var(--af-muted);
+}
+
+/* accent (required) field */
+.accentBox {
+    border-width: 1.5px;
+    border-color: color-mix(in oklch, var(--accent) 55%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 12%, transparent);
+}
+.accentBox .fieldIcon {
+    color: var(--accent);
+}
+.errorBox {
+    border-color: color-mix(in oklch, var(--af-error) 65%, transparent) !important;
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--af-error) 12%, transparent) !important;
+}
+.errorText {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11.5px;
+    color: var(--af-error);
+    margin-top: 6px;
+}
+
+/* textarea (block) */
+.textarea {
+    width: 100%;
+    background: var(--af-raised);
+    border: 1px solid var(--af-border-strong);
+    border-radius: 10px;
+    color: var(--af-text);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 13.5px;
+    line-height: 1.6;
+    padding: 12px 14px;
+    outline: none;
+    resize: vertical;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.textarea::placeholder {
+    color: var(--af-dim);
+}
+.textarea:focus {
+    border-color: color-mix(in oklch, var(--accent) 55%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 12%, transparent);
+}
+
+.grid2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+}
+@media (max-width: 600px) {
+    .grid2 {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* segmented */
+.segmented {
+    display: flex;
+    background: var(--af-surface);
+    border: 1px solid var(--af-border-strong);
+    border-radius: 10px;
+    padding: 4px;
+    gap: 4px;
+}
+.segItem {
+    flex: 1;
+    text-align: center;
+    padding: 10px 0;
+    border-radius: 7px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--af-muted);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 12.5px;
+}
+.segItemActive {
+    background: var(--af-raised);
+    color: var(--af-text);
+}
+
+/* toggle / checkbox */
+.toggleRow {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    cursor: pointer;
+    user-select: none;
+}
+.toggle {
+    width: 38px;
+    height: 22px;
+    border-radius: 999px;
+    background: var(--af-raised);
+    border: 1px solid var(--af-border-strong);
+    position: relative;
+    flex: none;
+    transition: background 140ms ease, border-color 140ms ease;
+}
+.toggleOn {
+    background: var(--accent);
+    border-color: transparent;
+}
+.knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--af-dim);
+    transition: transform 140ms ease, background 140ms ease;
+}
+.knobOn {
+    transform: translateX(16px);
+    background: #0A0B0E;
+}
+.toggleLabel {
+    font-size: 13px;
+    color: var(--af-text);
+}
+.warnBadge {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    color: var(--af-warning);
+    background: color-mix(in oklch, var(--af-warning) 12%, transparent);
+    border-radius: 6px;
+    padding: 3px 8px;
+    line-height: 1;
+}
+
+.checkRow {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    cursor: pointer;
+    user-select: none;
+}
+.checkbox {
+    width: 20px;
+    height: 20px;
+    border-radius: 6px;
+    border: 1.5px solid var(--af-border-strong);
+    background: var(--af-raised);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #0A0B0E;
+    flex: none;
+    transition: background 120ms ease, border-color 120ms ease;
+}
+.checkboxOn {
+    background: var(--accent);
+    border-color: transparent;
+}
+
+/* footer */
+.footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    border-top: 1px solid var(--af-border);
+    background: var(--af-bg);
+    padding: 18px 24px;
+}
+.hint {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11.5px;
+    color: var(--af-dim);
+}
+.actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: none;
+}
+.btnGhost {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 13px;
+    color: var(--af-muted);
+    padding: 11px 16px;
+    border-radius: 10px;
+    border: 1px solid var(--af-border-strong);
+    background: none;
+    cursor: pointer;
+    text-decoration: none;
+}
+.btnGhost:hover {
+    color: var(--af-text);
+    background: var(--af-raised);
+}
+.btnPrimary {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: #070A10;
+    padding: 12px 20px;
+    border-radius: 10px;
+    background: var(--accent);
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 0 22px color-mix(in oklch, var(--accent) 40%, transparent);
+    transition: filter 120ms ease;
+}
+.btnPrimary:hover {
+    filter: brightness(1.08);
+}
+.btnPrimary:disabled {
+    opacity: 0.6;
+    cursor: default;
+    box-shadow: none;
+}

--- a/src/components/Download/Modal/index.tsx
+++ b/src/components/Download/Modal/index.tsx
@@ -1,8 +1,14 @@
-import { LayerCard } from "@/components/LayerCard";
 import { Layer } from "@/lib/progressBus";
-import { Badge, Button, Center, Group, Loader, Modal, ModalProps, Progress, ScrollArea, Stack, Text } from "@mantine/core";
-import { IconCircleCheck, IconDownload, IconStackFront } from "@tabler/icons-react";
+import { Button, ModalProps, Text } from "@mantine/core";
+import { IconDownload } from "@tabler/icons-react";
 import { memo } from "react";
+import {
+    ProgressBanner,
+    ProgressModal,
+    type ProgressItem,
+    type ProgressItemStatus,
+} from "@/components/ProgressModal";
+import { type ManagerId } from "@/components/managers";
 
 type DownloadModalType = {
     repo: string;
@@ -11,7 +17,18 @@ type DownloadModalType = {
     layers: Layer[];
     perLayer: Record<number, { received: number; total?: number; status: "process"|"done"|"skipped"; }>;
     jobId: string|null;
+    accent?: ManagerId;
 } & ModalProps;
+
+function shortDigest(d: string) {
+    const v = d.includes(":") ? d.split(":").pop()! : d;
+    if (v.length <= 11) return v;
+    return `${v.slice(0, 6)}…${v.slice(-3)}`;
+}
+
+function mb(n: number) {
+    return `${(n / 1_000_000).toFixed(0)} MB`;
+}
 
 export const DownloadModal = memo(function DownloadModalMemo({
     repo,
@@ -20,155 +37,85 @@ export const DownloadModal = memo(function DownloadModalMemo({
     jobId,
     layers,
     perLayer,
+    accent = "docker",
     ...props
 }: DownloadModalType) {
 
     const totals = Object.values(perLayer).reduce(
-        (acc, v) => {
-            acc.received += v.received || 0; acc.total! += v.total || 0; return acc;
-        },
+        (acc, v) => { acc.received += v.received || 0; acc.total += v.total || 0; return acc; },
         { received: 0, total: 0 }
     );
-    const overallPercent = totals.total! > 0 ? Math.floor((totals.received / totals.total!) * 100) : undefined;
+    const overallPercent = totals.total > 0 ? Math.floor((totals.received / totals.total) * 100) : (status === "done" ? 100 : 0);
 
-    return (
-        <Modal
-            {...props}
-            centered
-            radius="lg"
-            size="lg"
-            transitionProps={{transition: "pop"}}
-            withCloseButton
-        >
-            <Group
-                justify="space-between"
-            >
-                <Group
-                    gap="xs"
-                >
-                    <IconStackFront />
-                    <Text
-                        fw="bold"
-                        size="lg"
-                    >
-                        ダウンロード進捗
-                    </Text>
-                </Group>
-                <Text
-                    size="xs"
-                >
-                    {jobId}
-                </Text>
-            </Group>
+    const doneCount = Object.values(perLayer).filter((v) => v.status === "done" || v.status === "skipped").length;
+    const total = layers.length;
 
-            <Group
-                justify="space-between"
-            >
-                <Text
-                    size="sm"
-                    c="dimmed"
-                >
-                    {repo}:{tag}・{layers.length}Layers
-                </Text>
-                {status=="done" ? (
-                    <Badge
-                        leftSection={<IconCircleCheck size="1em"/>}
-                        color="green"
-                        radius="sm"
-                    >
-                        done
-                    </Badge>
-                ):(
-                    <Badge
-                        leftSection={<Loader size="1em" color="white"/>}
-                        color="gray"
-                        radius="sm"
-                    >
-                        {status}
-                    </Badge>
-                )}
-            </Group>
+    const state: "running" | "done" | "error" = status === "done" ? "done" : status === "error" ? "error" : "running";
+    const indeterminate = status === "starting" || status === "running" || layers.length === 0;
 
-            <Stack
-                py="md"
-                gap={10}
-            >
-                <Group
-                    justify="space-between"
-                >
-                    <Text
-                        fw="bold"
-                    >
-                        全体の進捗
-                    </Text>
-                    <Text>
-                        {overallPercent}%
-                    </Text>
-                </Group>
-                <Progress
-                    value={overallPercent || 0}
-                    size="lg"
-                />
-                <Text
-                    color="dimmed"
-                    size="xs"
-                >
-                    {(totals.received / 1_000_000).toFixed(2)}MB / {((totals.total ?? 0) / 1_000_000).toFixed(2)}MB
-                </Text>
-            </Stack>
+    const items: ProgressItem[] = layers.map((layer, i) => {
+        const info = perLayer[i];
+        const rawStatus = info?.status ?? "process";
+        const st: ProgressItemStatus =
+            rawStatus === "done" ? "done" :
+            rawStatus === "skipped" ? "skipped" :
+            (info?.received ?? 0) > 0 ? "running" : "waiting";
+        const pct = info?.total ? Math.floor(((info.received || 0) / info.total) * 100) : 0;
+        const meta =
+            st === "skipped" ? "skip" :
+            st === "waiting" ? "待機" :
+            info?.total ? mb(info.total) : `${pct}%`;
+        return { key: `${i}`, label: shortDigest(layer.digest), status: st, percent: pct, meta };
+    });
 
-            {status=="starting"||status=="running" ? (
-                <Center
-                    h={400}
-                >
-                    <Loader />
-                </Center>
-            ) : (
-                <ScrollArea
-                    h={400}
-                >
-                    <Stack>
-                        {layers.map((layer, i) => {
-                            const info = perLayer[i];
-                            const pct = info?.total ? Math.floor((info.received / info.total) * 100) : undefined;
-                            return (
-                                <LayerCard
-                                    key={i}
-                                    number={i}
-                                    progress={pct || 0}
-                                    sha={layer.digest}
-                                    total={info?.total || 0}
-                                    received={info?.received || 0}
-                                    status={info?.status || "process"}
-                                />
-                            )
-                        })}
-                    </Stack>
-                </ScrollArea>
-            )}
+    const banner = state === "done" ? (
+        <ProgressBanner
+            tone="success"
+            title={`${total} 項目すべて取得しました`}
+            detail={`${repo}:${tag} · ${mb(totals.total || totals.received)}`}
+        />
+    ) : undefined;
 
+    const footer = state === "done" ? (
+        <>
+            <Button variant="default" radius="md" onClick={() => props.onClose?.()}>閉じる</Button>
             <Button
-                leftSection={<IconDownload size="1rem"/>}
-                fullWidth
-                radius="lg"
-                mt="lg"
-                color="dark"
-                disabled={jobId==null || status!="done"}
+                color="success"
+                radius="md"
+                leftSection={<IconDownload size="1rem" />}
                 component="a"
                 href={`/api/build/download?jobId=${jobId}`}
                 target="_blank"
+                disabled={jobId == null}
             >
-                ダウンロード
+                アーカイブをダウンロード
             </Button>
-            <Button
-                variant="outline"
-                fullWidth
-                radius="lg"
-                mt="sm"
-                onClick={() => props.onClose?.()}
-            >
-                閉じる
-            </Button>
-        </Modal>
+        </>
+    ) : (
+        <>
+            <Text className="af-mono" fz={12.5} c="var(--af-muted)">
+                {indeterminate ? "依存を解決しています…" : `${doneCount} / ${total} layers`}
+            </Text>
+            <Button variant="default" radius="md" onClick={() => props.onClose?.()}>キャンセル</Button>
+        </>
+    );
+
+    return (
+        <ProgressModal
+            {...props}
+            accent={accent}
+            title={state === "done" ? "取得完了" : state === "error" ? "取得に失敗" : "取得中"}
+            subtitle={`${repo}:${tag}`}
+            overallPercent={indeterminate ? undefined : overallPercent}
+            state={state}
+            stats={[
+                { value: doneCount, unit: `/${total}`, label: "完了 / 全体", accent: state === "done" },
+                { value: mb(totals.received).replace(" MB", ""), unit: " MB", label: "取得サイズ" },
+                { value: total, label: "レイヤ数" },
+            ]}
+            items={items}
+            banner={banner}
+            footer={footer}
+        />
     );
 });

--- a/src/components/FormCard/index.tsx
+++ b/src/components/FormCard/index.tsx
@@ -1,0 +1,29 @@
+import { Box, Group } from "@mantine/core";
+import { ReactNode } from "react";
+import classes from "./styles.module.css";
+
+/**
+ * Bordered form container with an optional action footer
+ * (hint text on the left, buttons on the right) — Carbon design.
+ */
+export function FormCard({
+    children,
+    hint,
+    actions,
+}: {
+    children: ReactNode;
+    hint?: ReactNode;
+    actions?: ReactNode;
+}) {
+    return (
+        <Box className={classes.card}>
+            <Box className={classes.body}>{children}</Box>
+            {(hint || actions) && (
+                <Group className={classes.footer} justify="space-between" wrap="nowrap">
+                    <Box style={{ minWidth: 0 }}>{hint}</Box>
+                    <Group gap="sm" wrap="nowrap" style={{ flex: "none" }}>{actions}</Group>
+                </Group>
+            )}
+        </Box>
+    );
+}

--- a/src/components/FormCard/styles.module.css
+++ b/src/components/FormCard/styles.module.css
@@ -1,0 +1,16 @@
+.card {
+    background: var(--af-surface);
+    border: 1px solid var(--af-border);
+    border-radius: var(--mantine-radius-lg);
+    overflow: hidden;
+}
+
+.body {
+    padding: 24px;
+}
+
+.footer {
+    padding: 16px 24px;
+    border-top: 1px solid var(--af-border);
+    background: var(--af-bg);
+}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,8 +1,10 @@
 'use client';
-import { Group, Anchor, ActionIcon, useMantineColorScheme, Burger } from "@mantine/core";
+import { Group, ActionIcon, useMantineColorScheme, Burger, Box } from "@mantine/core";
 import { IconBrandGithubFilled, IconMoon, IconSun } from "@tabler/icons-react";
-import classes from "./styles.module.css";
+import { usePathname } from "next/navigation";
 import { AppTitle } from "../AppTitle";
+import { MANAGERS } from "../managers";
+import classes from "./styles.module.css";
 
 export const AppHeader = ({
     navbarOpened,
@@ -13,73 +15,83 @@ export const AppHeader = ({
 }) => {
 
     const { setColorScheme } = useMantineColorScheme();
+    const pathname = usePathname();
 
     return (
         <Group
             justify="space-between"
             h={60}
+            wrap="nowrap"
         >
             <Group
                 align="center"
+                wrap="nowrap"
+                gap="md"
             >
                 <Burger
                     size="sm"
-                    hiddenFrom="xs"
+                    hiddenFrom="sm"
                     onClick={toggleNavbar}
                     opened={navbarOpened}
                 />
                 <AppTitle />
+                <Group
+                    gap={4}
+                    visibleFrom="sm"
+                    ml="xs"
+                    wrap="nowrap"
+                >
+                    {MANAGERS.map((m) => {
+                        const active = pathname?.startsWith(m.href);
+                        return (
+                            <Box
+                                key={m.id}
+                                component="a"
+                                href={m.href}
+                                className={classes.navLink}
+                                data-active={active || undefined}
+                                style={active ? {
+                                    color: `var(--af-${m.color})`,
+                                    background: `color-mix(in oklch, var(--af-${m.color}) 14%, transparent)`,
+                                } : undefined}
+                            >
+                                {m.label}
+                            </Box>
+                        );
+                    })}
+                </Group>
             </Group>
-            <Group>
-                <Anchor
-                    href="/docker"
-                    className={classes.link}
-                    visibleFrom="xs"
-                >
-                    docker
-                </Anchor>
-                <Anchor
-                    href="/npm"
-                    className={classes.link}
-                    visibleFrom="xs"
-                >
-                    npm
-                </Anchor>
-                <Anchor
-                    href="/pip"
-                    className={classes.link}
-                    visibleFrom="xs"
-                >
-                    pip
-                </Anchor>
+            <Group gap="xs" wrap="nowrap">
                 <ActionIcon
-                    variant="transparent"
-                    color="gray"
+                    variant="default"
+                    size="lg"
+                    radius="md"
                     component="a"
                     href="https://github.com/Gariton/ArtifactFetcher"
                     target="_blank"
+                    aria-label="GitHub"
                 >
-                    <IconBrandGithubFilled
-                        size="1.3em"
-                    />
+                    <IconBrandGithubFilled size="1.1rem" />
                 </ActionIcon>
                 <ActionIcon
                     variant="default"
-                    color="gray"
+                    size="lg"
                     onClick={()=>setColorScheme("light")}
                     radius="md"
                     lightHidden
+                    aria-label="ライトモード"
                 >
-                    <IconSun size="1rem"/>
+                    <IconSun size="1.05rem"/>
                 </ActionIcon>
                 <ActionIcon
                     variant="default"
-                    color="gray"
+                    size="lg"
                     onClick={()=>setColorScheme("dark")}
                     radius="md"
                     darkHidden
+                    aria-label="ダークモード"
                 >
-                    <IconMoon size="1rem"/>
+                    <IconMoon size="1.05rem"/>
                 </ActionIcon>
             </Group>
         </Group>

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -1,4 +1,17 @@
-.link {
-    border-radius: var(--mantine-radius-md);
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-0));
+.navLink {
+    display: inline-flex;
+    align-items: center;
+    padding: 7px 13px;
+    border-radius: var(--mantine-radius-sm);
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    text-decoration: none;
+    color: var(--af-muted);
+    transition: background 120ms ease, color 120ms ease;
+}
+
+.navLink:hover {
+    color: var(--af-text);
+    background: var(--af-border);
 }

--- a/src/components/LayerCard/index.tsx
+++ b/src/components/LayerCard/index.tsx
@@ -72,12 +72,17 @@ export const LayerCard = memo(function LayerCardMemo({
                     <Text
                         size="xs"
                         lineClamp={1}
+                        ff="monospace"
+                        c="dimmed"
                     >
                         {sha}
                     </Text>
                     {status !== "skipped" && (
                         <Progress
                             value={progress}
+                            color={status === "done" ? "success" : "docker"}
+                            radius="xl"
+                            mt={4}
                         />
                     )}
                 </div>

--- a/src/components/Layout/default.tsx
+++ b/src/components/Layout/default.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Text, AppShell, Container, Flex, Center } from "@mantine/core";
+import { Text, AppShell, Container, Flex, Group } from "@mantine/core";
 import { Notifications } from "@mantine/notifications";
 import { ReactNode } from "react";
 
@@ -13,7 +13,7 @@ import { AppNavbar } from "@/components/Navbar";
 export const DefalutLayout = ({
     children
 }: {children: ReactNode}) => {
-    const [opened, {toggle}] = useDisclosure(false);
+    const [opened, {toggle, close}] = useDisclosure(false);
     return (
         <>
             <Notifications position="top-right" />
@@ -22,14 +22,17 @@ export const DefalutLayout = ({
                 height: 60
             }}
             navbar={{
-                width: 150,
-                breakpoint: "xs",
+                width: 260,
+                breakpoint: "sm",
                 collapsed: {desktop: true, mobile: !opened}
             }}
         >
-            <AppShell.Header>
+            <AppShell.Header
+                style={{ borderBottom: "1px solid var(--af-border)", background: "var(--af-bg)" }}
+            >
                 <Container
                     size="md"
+                    h="100%"
                 >
                     <AppHeader
                         navbarOpened={opened}
@@ -38,7 +41,9 @@ export const DefalutLayout = ({
                 </Container>
             </AppShell.Header>
             <AppShell.Navbar
-                hiddenFrom="xs"
+                hiddenFrom="sm"
+                style={{ background: "var(--af-surface)", borderRight: "1px solid var(--af-border)" }}
+                onClick={close}
             >
                 <AppNavbar />
             </AppShell.Navbar>
@@ -50,20 +55,25 @@ export const DefalutLayout = ({
                 >
                     <Container
                         size="md"
-                        pt="md"
+                        pt="xl"
                         flex={1}
+                        w="100%"
                     >
                         {children}
                     </Container>
-                    <Center
-                        h={50}
+                    <Group
+                        h={56}
+                        px="md"
+                        justify="space-between"
+                        style={{ borderTop: "1px solid var(--af-border)" }}
                     >
-                        <Text
-                            ta="center"
-                        >
+                        <Text className="af-mono" fz={11} c="var(--af-dim)">
                             © 2025 Gariton_
                         </Text>
-                    </Center>
+                        <Text className="af-mono" fz={11} c="var(--af-dim)" visibleFrom="xs">
+                            air-gapped registry mirror
+                        </Text>
+                    </Group>
                 </Flex>
             </AppShell.Main>
             </AppShell>

--- a/src/components/ManagerCatalog/index.tsx
+++ b/src/components/ManagerCatalog/index.tsx
@@ -1,82 +1,77 @@
 'use client';
 
-import { ActionIcon, Button, Modal, SimpleGrid, Stack, Text, Tooltip } from '@mantine/core';
-import { TablerIcon } from '@tabler/icons-react';
-// import * as TablerIconsProps from '@tabler/icons-react';
-import { ReactNode, useState } from 'react';
+import { Box, Group, SimpleGrid, Stack, Text } from '@mantine/core';
+import { IconChevronRight, IconLayoutList } from '@tabler/icons-react';
+import { AccentTile } from '../AccentTile';
+import { MANAGERS, type Manager } from '../managers';
+import classes from './styles.module.css';
 
-export type ManagerEntry = {
-    id: string;
-    name: string;
-    description: string;
-    href: string;
-    Icon: TablerIcon;
-    color?: string;
-};
-
-type ManagerCatalogProps = {
-    entries: ManagerEntry[];
-};
-
-export function ManagerCatalog({ entries }: ManagerCatalogProps) {
-    const [selected, setSelected] = useState<ManagerEntry | null>(null);
-
+function ManagerCard({ m }: { m: Manager }) {
     return (
-        <>
-            <SimpleGrid
-                cols={{ base: 2, sm: 3 }}
-                spacing={{ base: 'lg', sm: 'xl' }}
-                verticalSpacing={{ base: 'lg', sm: 'xl' }}
-            >
-                {entries.map((entry) => (
-                    <div
-                        key={entry.id}
-                        style={{ display: 'flex', justifyContent: 'center' }}
+        <Box
+            component="a"
+            href={m.href}
+            className={classes.card}
+            style={{
+                ['--accent' as string]: `var(--af-${m.color})`,
+            }}
+        >
+            <Group justify="space-between" align="flex-start">
+                <AccentTile color={m.color} code={m.code} size="lg" />
+                <span className={classes.chevron} style={{ color: `var(--af-${m.color})` }}>
+                    <IconChevronRight size={20} stroke={1.7} />
+                </span>
+            </Group>
+            <Stack gap={7} mt="md">
+                <Text fz={18} fw={600} style={{ letterSpacing: '-0.01em' }}>
+                    {m.label}
+                </Text>
+                <Text fz={13.5} c="var(--af-muted)" lh={1.6}>
+                    {m.blurb}
+                </Text>
+            </Stack>
+            <Group gap={7} mt="auto" pt="md">
+                {m.tags.map((t) => (
+                    <span
+                        key={t}
+                        className={`${classes.tag} af-mono`}
+                        style={{
+                            color: `var(--af-${m.color})`,
+                            background: `color-mix(in oklch, var(--af-${m.color}) 12%, transparent)`,
+                        }}
                     >
-                        <Tooltip
-                            label={entry.name}
-                            position="top"
-                            withArrow
-                        >
-                            <ActionIcon
-                                size={110}
-                                radius="xl"
-                                variant="light"
-                                color={entry.color ?? 'gray'}
-                                onClick={() => setSelected(entry)}
-                                aria-label={`${entry.name} の詳細を表示`}
-                                style={{ width: 110, height: 110 }}
-                            >
-                                <entry.Icon size={48} stroke={1.3} />
-                            </ActionIcon>
-                        </Tooltip>
-                    </div>
+                        {t}
+                    </span>
                 ))}
-            </SimpleGrid>
+            </Group>
+        </Box>
+    );
+}
 
-            <Modal
-                opened={selected !== null}
-                onClose={() => setSelected(null)}
-                title={selected?.name}
-                centered
-                radius="lg"
+export function ManagerCatalog() {
+    return (
+        <Stack gap="md">
+            <Text className="af-eyebrow">5 つの成果物マネージャ</Text>
+            <SimpleGrid
+                cols={{ base: 1, xs: 2, md: 3 }}
+                spacing="lg"
             >
-                {selected && (
-                    <Stack gap="md">
-                        <Text size="sm" c="dimmed">
-                            {selected.description}
-                        </Text>
-                        <Button
-                            component="a"
-                            href={selected.href}
-                            radius="lg"
-                            color={selected.color ?? 'dark'}
-                        >
-                            {selected.name}ページへ移動
-                        </Button>
-                    </Stack>
-                )}
-            </Modal>
-        </>
+                {MANAGERS.map((m) => (
+                    <ManagerCard key={m.id} m={m} />
+                ))}
+
+                <Box component="a" href="/admin" className={classes.adminCard}>
+                    <Group gap="md" align="center" h="100%">
+                        <span className={classes.adminIcon}>
+                            <IconLayoutList size={22} stroke={1.6} />
+                        </span>
+                        <div>
+                            <Text fz={14} fw={600} c="var(--af-text)">管理 / ログ</Text>
+                            <Text fz={12} c="var(--af-dim)" mt={3}>リクエスト履歴の確認</Text>
+                        </div>
+                    </Group>
+                </Box>
+            </SimpleGrid>
+        </Stack>
     );
 }

--- a/src/components/ManagerCatalog/styles.module.css
+++ b/src/components/ManagerCatalog/styles.module.css
@@ -1,0 +1,68 @@
+.card {
+    display: flex;
+    flex-direction: column;
+    min-height: 196px;
+    padding: 22px;
+    border-radius: var(--mantine-radius-lg);
+    border: 1px solid color-mix(in oklch, var(--accent) 30%, transparent);
+    background: linear-gradient(
+        180deg,
+        color-mix(in oklch, var(--accent) 6%, transparent),
+        color-mix(in oklch, var(--accent) 1.5%, transparent)
+    );
+    text-decoration: none;
+    color: var(--af-text);
+    transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+}
+
+.card:hover {
+    transform: translateY(-3px);
+    border-color: color-mix(in oklch, var(--accent) 50%, transparent);
+    box-shadow: 0 14px 36px color-mix(in oklch, var(--accent) 18%, transparent);
+}
+
+.chevron {
+    opacity: 0.65;
+    transition: transform 140ms ease, opacity 140ms ease;
+}
+
+.card:hover .chevron {
+    opacity: 1;
+    transform: translateX(3px);
+}
+
+.tag {
+    font-size: 10px;
+    border-radius: 6px;
+    padding: 4px 9px;
+    line-height: 1;
+}
+
+.adminCard {
+    display: flex;
+    align-items: center;
+    min-height: 196px;
+    padding: 22px;
+    border-radius: var(--mantine-radius-lg);
+    border: 1px dashed var(--af-border-strong);
+    background: var(--af-surface);
+    text-decoration: none;
+    transition: border-color 140ms ease, background 140ms ease;
+}
+
+.adminCard:hover {
+    border-color: var(--af-muted);
+    background: var(--af-raised);
+}
+
+.adminIcon {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--af-muted);
+    background: var(--af-raised);
+    flex: none;
+}

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,47 +1,51 @@
-import { Anchor, Stack } from "@mantine/core";
+'use client';
+import { Box, Divider, Stack, Text } from "@mantine/core";
+import { IconLayoutList } from "@tabler/icons-react";
+import { usePathname } from "next/navigation";
+import { AccentTile } from "../AccentTile";
+import { MANAGERS } from "../managers";
 import classes from "./styles.module.css";
 
 export const AppNavbar = () => {
+    const pathname = usePathname();
     return (
-        <Stack
-            p="md"
-        >
-            <Anchor
-                className={classes.link}
-                href="/docker"
-            >
-                docker
-            </Anchor>
-            <Anchor
-                className={classes.link}
-                href="/npm"
-            >
-                npm
-            </Anchor>
-            <Anchor
-                className={classes.link}
-                href="/pip"
-            >
-                pip
-            </Anchor>
-            <Anchor
-                className={classes.link}
-                href="/rpm"
-            >
-                rpm
-            </Anchor>
-            <Anchor
-                className={classes.link}
-                href="/hf"
-            >
-                huggingface
-            </Anchor>
-            <Anchor
-                className={classes.link}
+        <Stack p="sm" gap={4}>
+            {MANAGERS.map((m) => {
+                const active = pathname?.startsWith(m.href);
+                return (
+                    <Box
+                        key={m.id}
+                        component="a"
+                        href={m.href}
+                        className={classes.link}
+                        data-active={active || undefined}
+                        style={active ? {
+                            background: `color-mix(in oklch, var(--af-${m.color}) 14%, transparent)`,
+                        } : undefined}
+                    >
+                        <AccentTile color={m.color} code={m.code} size="md" />
+                        <Text
+                            fz={14}
+                            fw={active ? 600 : 400}
+                            style={{ color: active ? `var(--af-${m.color})` : "var(--af-text)" }}
+                        >
+                            {m.label}
+                        </Text>
+                    </Box>
+                );
+            })}
+            <Divider my="xs" color="var(--af-border)" />
+            <Box
+                component="a"
                 href="/admin"
+                className={classes.link}
+                data-active={pathname?.startsWith("/admin") || undefined}
             >
-                管理
-            </Anchor>
+                <span className={classes.adminIcon}>
+                    <IconLayoutList size={18} stroke={1.6} />
+                </span>
+                <Text fz={14} c="var(--af-muted)">管理 / ログ</Text>
+            </Box>
         </Stack>
     );
 }

--- a/src/components/Navbar/styles.module.css
+++ b/src/components/Navbar/styles.module.css
@@ -1,3 +1,23 @@
 .link {
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-0));
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: var(--mantine-radius-md);
+    text-decoration: none;
+    transition: background 120ms ease;
+}
+
+.link:hover {
+    background: var(--af-border);
+}
+
+.adminIcon {
+    width: 30px;
+    height: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--af-muted);
+    flex: none;
 }

--- a/src/components/PackageUpload/Modal/index.tsx
+++ b/src/components/PackageUpload/Modal/index.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { Badge, Button, Group, Loader, Modal, ModalProps, Progress, ScrollArea, Stack, Text } from '@mantine/core';
-import { IconCircleCheck, IconHourglassLow, IconStackFront } from '@tabler/icons-react';
+import { Button, ModalProps, Text } from '@mantine/core';
+import {
+    ProgressBanner,
+    ProgressModal,
+    type ProgressItem,
+    type ProgressItemStatus,
+} from '@/components/ProgressModal';
+import { type ManagerId } from '@/components/managers';
 
 type FileProgress = {
     received: number;
@@ -14,135 +20,91 @@ type Props = {
     perFile: Record<number, FileProgress>;
     status: 'idle' | 'running' | 'done' | 'error';
     jobId: string | null;
+    accent?: ManagerId;
 } & ModalProps;
 
-function statusBadge(status: Props['status']) {
-    switch (status) {
-        case 'done':
-            return (
-                <Badge color="green" leftSection={<IconCircleCheck size="1em" />} radius="sm">
-                    done
-                </Badge>
-            );
+function mapStatus(s?: string): ProgressItemStatus {
+    switch (s) {
+        case 'uploaded':
+        case 'published':
+            return 'done';
+        case 'uploading':
+        case 'publishing':
+            return 'running';
         case 'error':
-            return (
-                <Badge color="red" radius="sm">
-                    error
-                </Badge>
-            );
-        case 'running':
-            return (
-                <Badge color="gray" leftSection={<Loader size="1em" color="white" />} radius="sm">
-                    running
-                </Badge>
-            );
+            return 'error';
         default:
-            return (
-                <Badge color="gray" radius="sm" leftSection={<IconHourglassLow size="1em" />}>
-                    idle
-                </Badge>
-            );
+            return 'waiting';
     }
 }
 
-export function PackageUploadModal({ files, perFile, status, jobId, onClose, ...props }: Props) {
-    return (
-        <Modal
-            {...props}
-            centered
-            radius="lg"
-            size="lg"
-            transitionProps={{ transition: 'pop' }}
-            onClose={onClose}
-            withCloseButton={false}
-        >
-            <Stack gap="md">
-                <Group justify="space-between">
-                    <Group gap="xs">
-                        <IconStackFront />
-                        <Text fw="bold" size="lg">
-                            アップロード進捗
-                        </Text>
-                    </Group>
-                    {statusBadge(status)}
-                </Group>
-                {jobId && (
-                    <Text size="xs" c="dimmed">
-                        jobId: {jobId}
-                    </Text>
-                )}
-                <ScrollArea
-                    h={550}
-                >
-                    <Stack gap="sm">
-                        {files.length === 0 ? (
-                            <Text c="dimmed" size="sm">
-                                ファイルが選択されていません。
-                            </Text>
-                        ) : (
-                            files.map((file, idx) => {
-                                const info = perFile[idx];
-                                const total = info?.total ?? file.size;
-                                const received = info?.received ?? 0;
-                                const percent = total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0;
-                                const statusLabel = (() => {
-                                    switch (info?.status) {
-                                        case 'uploading':
-                                            return 'uploading';
-                                        case 'uploaded':
-                                            return 'uploaded';
-                                        case 'publishing':
-                                            return 'publishing';
-                                        case 'published':
-                                            return 'published';
-                                        case 'waiting':
-                                            return 'waiting';
-                                        default:
-                                            return info?.status ?? 'waiting';
-                                    }
-                                })();
-                                const badgeColor = (() => {
-                                    switch (statusLabel) {
-                                        case 'publishing':
-                                        case 'uploading':
-                                            return 'blue';
-                                        case 'published':
-                                            return 'green';
-                                        case 'uploaded':
-                                            return 'teal';
-                                        case 'error':
-                                            return 'red';
-                                        case 'waiting':
-                                            return 'gray';
-                                        default:
-                                            return 'gray';
-                                    }
-                                })();
-                                return (
-                                    <Stack key={`${file.name}-${idx}`} gap={4}>
-                                        <Group justify="space-between">
-                                            <Text size="sm" fw={500} lineClamp={1}>
-                                                {file.name}
-                                            </Text>
-                                            <Badge radius="sm" color={badgeColor}>
-                                                {statusLabel}
-                                            </Badge>
-                                        </Group>
-                                        <Progress value={percent} size="lg" radius="xl" />
-                                        <Text size="xs" c="dimmed">
-                                            {(received / 1_000_000).toFixed(2)}MB / {(total / 1_000_000).toFixed(2)}MB
-                                        </Text>
-                                    </Stack>
-                                );
-                            })
-                        )}
-                    </Stack>
-                </ScrollArea>
+function mb(n: number) {
+    return `${(n / 1_000_000).toFixed(1)} MB`;
+}
 
-                <Button onClick={onClose} variant="outline" radius="lg">
-                    閉じる
-                </Button>
-            </Stack>
-        </Modal>
+export function PackageUploadModal({ files, perFile, status, jobId, onClose, accent = 'npm', ...props }: Props) {
+    const items: ProgressItem[] = files.map((file, idx) => {
+        const info = perFile[idx];
+        const total = info?.total ?? file.size;
+        const received = info?.received ?? 0;
+        const st = mapStatus(info?.status);
+        const percent = total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0;
+        const meta =
+            st === 'done' ? '完了' :
+            st === 'waiting' ? '待機' :
+            st === 'error' ? 'error' :
+            `${percent}%`;
+        return {
+            key: `${file.name}-${idx}`,
+            label: file.name,
+            status: st,
+            percent,
+            meta,
+            error: st === 'error' ? 'アップロードに失敗しました' : undefined,
+        };
+    });
+
+    const doneCount = items.filter((i) => i.status === 'done').length;
+    const errorCount = items.filter((i) => i.status === 'error').length;
+    const totalSize = files.reduce((a, f) => a + (perFile[files.indexOf(f)]?.total ?? f.size), 0);
+    const overall = files.length > 0 ? Math.floor((doneCount / files.length) * 100) : 0;
+
+    const state: 'running' | 'done' | 'error' =
+        status === 'done' ? 'done' : (status === 'error' || errorCount > 0) && status !== 'running' ? 'error' : status === 'running' ? 'running' : 'running';
+
+    const banner =
+        state === 'done' ? (
+            <ProgressBanner tone="success" title={`${doneCount} 件すべて publish しました`} detail={`${files.length} ファイル · ${mb(totalSize)}`} />
+        ) : state === 'error' ? (
+            <ProgressBanner tone="error" title={`${doneCount} 件完了 · ${errorCount} 件失敗`} detail="失敗した項目は再試行できます。" />
+        ) : undefined;
+
+    const footer = (
+        <>
+            <Text className="af-mono" fz={12.5} c="var(--af-muted)">
+                {doneCount} / {files.length} 完了
+            </Text>
+            <Button variant="default" radius="md" onClick={onClose}>閉じる</Button>
+        </>
+    );
+
+    return (
+        <ProgressModal
+            {...props}
+            onClose={onClose}
+            accent={accent}
+            title={state === 'done' ? 'アップロード完了' : state === 'error' ? '一部の項目で失敗' : 'アップロード中'}
+            subtitle={jobId ? `job ${jobId}` : `${files.length} ファイル`}
+            overallPercent={files.length === 0 ? undefined : overall}
+            state={state}
+            stats={[
+                { value: doneCount, unit: `/${files.length}`, label: '完了', accent: state === 'done' },
+                { value: errorCount, label: '失敗' },
+                { value: mb(totalSize).replace(' MB', ''), unit: ' MB', label: '合計' },
+            ]}
+            items={items}
+            banner={banner}
+            footer={footer}
+        />
     );
 }

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -1,0 +1,27 @@
+import { Group, Stack, Text, Title } from "@mantine/core";
+import { AccentTile } from "../AccentTile";
+import { MANAGERS_BY_ID, type ManagerId } from "../managers";
+import { ReactNode } from "react";
+
+export function PageHeader({
+    manager,
+    description,
+}: {
+    manager: ManagerId;
+    description: ReactNode;
+}) {
+    const m = MANAGERS_BY_ID[manager];
+    return (
+        <Group align="center" gap="md" wrap="nowrap" mb="lg">
+            <AccentTile color={m.color} code={m.code} size="xl" />
+            <Stack gap={4}>
+                <Title order={1} fz={28} style={{ letterSpacing: "-0.02em", lineHeight: 1.1 }}>
+                    {m.label}
+                </Title>
+                <Text fz={14} c="var(--af-muted)">
+                    {description}
+                </Text>
+            </Stack>
+        </Group>
+    );
+}

--- a/src/components/ProgressModal/index.tsx
+++ b/src/components/ProgressModal/index.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { Box, Group, Modal, ModalProps, Stack, Text } from "@mantine/core";
+import {
+    IconAlertTriangle,
+    IconCheck,
+    IconCircleCheck,
+    IconClock,
+    IconLoader2,
+    IconMinus,
+} from "@tabler/icons-react";
+import { ReactNode } from "react";
+import { AccentTile } from "../AccentTile";
+import { type ManagerId } from "../managers";
+import classes from "./styles.module.css";
+
+export type ProgressItemStatus = "waiting" | "running" | "done" | "skipped" | "error";
+
+export type ProgressItem = {
+    key: string;
+    /** mono label — sha / filename */
+    label: string;
+    status: ProgressItemStatus;
+    percent?: number;
+    /** right-aligned meta (size / state) */
+    meta?: string;
+    error?: string;
+};
+
+export type ProgressStat = {
+    value: ReactNode;
+    unit?: string;
+    label: string;
+    accent?: boolean;
+};
+
+function StatusIcon({ status, accent }: { status: ProgressItemStatus; accent: string }) {
+    switch (status) {
+        case "done":
+            return <IconCheck size={16} stroke={2.4} color="var(--af-success)" />;
+        case "running":
+            return <IconLoader2 size={16} stroke={2.2} color={accent} className={classes.spin} />;
+        case "skipped":
+            return <IconMinus size={15} stroke={2} color="var(--af-skipped)" />;
+        case "error":
+            return <IconAlertTriangle size={16} stroke={2.2} color="var(--af-error)" />;
+        default:
+            return <IconClock size={15} stroke={1.8} color="var(--af-dim)" />;
+    }
+}
+
+function ItemRow({ item, accent }: { item: ProgressItem; accent: string }) {
+    const isError = item.status === "error";
+    if (isError) {
+        return (
+            <Box className={classes.errorRow}>
+                <Group gap={11} wrap="nowrap" align="center">
+                    <StatusIcon status="error" accent={accent} />
+                    <Text className="af-mono" fz={11.5} flex={1} style={{ color: "#E6C0C0", wordBreak: "break-all" }}>
+                        {item.label}
+                    </Text>
+                    {item.meta && (
+                        <Text className="af-mono" fz={11} c="var(--af-error)" style={{ flex: "none" }}>
+                            {item.meta}
+                        </Text>
+                    )}
+                </Group>
+                {item.error && (
+                    <Text className="af-mono" fz={11} mt={8} pl={27} style={{ color: "var(--af-error)", opacity: 0.85 }}>
+                        {item.error}
+                    </Text>
+                )}
+            </Box>
+        );
+    }
+    const barColor =
+        item.status === "done" ? "color-mix(in oklch, var(--af-success) 60%, transparent)" :
+        item.status === "running" ? accent : "transparent";
+    const pct = item.status === "done" ? 100 : item.percent ?? 0;
+    return (
+        <Group gap={11} wrap="nowrap" align="center" className={item.status === "waiting" ? classes.waiting : undefined}>
+            <span style={{ flex: "none", display: "inline-flex" }}>
+                <StatusIcon status={item.status} accent={accent} />
+            </span>
+            <Text
+                className="af-mono"
+                fz={11.5}
+                style={{
+                    flex: "none",
+                    width: 92,
+                    color: item.status === "running" ? "var(--af-text)" : "var(--af-muted)",
+                    textDecoration: item.status === "done" ? "line-through" : undefined,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                }}
+            >
+                {item.label}
+            </Text>
+            <div className={classes.track}>
+                <div
+                    className={classes.fill}
+                    style={{
+                        width: `${pct}%`,
+                        background: barColor,
+                        boxShadow: item.status === "running" ? `0 0 8px color-mix(in oklch, ${accent} 60%, transparent)` : undefined,
+                    }}
+                />
+            </div>
+            <Text className="af-mono" fz={10.5} style={{ flex: "none", width: 52, textAlign: "right", color: "var(--af-dim)" }}>
+                {item.meta ?? ""}
+            </Text>
+        </Group>
+    );
+}
+
+export type ProgressModalProps = {
+    accent: ManagerId;
+    title: string;
+    subtitle: string;
+    /** 0-100, or undefined for indeterminate */
+    overallPercent?: number;
+    state: "running" | "done" | "error";
+    stats?: ProgressStat[];
+    items: ProgressItem[];
+    /** optional banner under the header (done/partial) */
+    banner?: ReactNode;
+    /** optional extra panel (e.g. live logs) rendered above the item list */
+    extra?: ReactNode;
+    footer: ReactNode;
+} & Omit<ModalProps, "title" | "children">;
+
+export function ProgressModal({
+    accent,
+    title,
+    subtitle,
+    overallPercent,
+    state,
+    stats,
+    items,
+    banner,
+    extra,
+    footer,
+    ...props
+}: ProgressModalProps) {
+    const accentVar = `var(--af-${accent})`;
+    const code = accent.toUpperCase().slice(0, 3);
+    const pctColor = state === "error" ? "var(--af-error)" : state === "done" ? "var(--af-success)" : accentVar;
+
+    return (
+        <Modal
+            {...props}
+            centered
+            radius="lg"
+            size="lg"
+            withCloseButton={false}
+            padding={0}
+            transitionProps={{ transition: "pop" }}
+            classNames={{ content: classes.modalContent }}
+        >
+            {/* header */}
+            <Group className={classes.header} gap={13} wrap="nowrap">
+                <AccentTile color={accent} code={code} size="lg" />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <Text fz={15} fw={600}>{title}</Text>
+                    <Text className="af-mono" fz={11} c="var(--af-dim)" mt={2} truncate>{subtitle}</Text>
+                </div>
+            </Group>
+
+            {banner}
+
+            {/* overall dashboard */}
+            <Box className={classes.section}>
+                <Group justify="space-between" align="baseline" mb={12}>
+                    <Text fz={13} c="var(--af-muted)">全体の進捗</Text>
+                    <Text className="af-mono" fz={22} fw={600} style={{ color: pctColor }}>
+                        {overallPercent ?? 0}%
+                    </Text>
+                </Group>
+                <div className={classes.overallTrack}>
+                    <div
+                        className={classes.overallFill}
+                        style={{
+                            width: `${overallPercent ?? 0}%`,
+                            background: `linear-gradient(90deg, color-mix(in oklch, ${pctColor} 80%, black), ${pctColor})`,
+                            boxShadow: `0 0 12px color-mix(in oklch, ${pctColor} 50%, transparent)`,
+                        }}
+                    />
+                </div>
+                {stats && stats.length > 0 && (
+                    <Group gap={10} mt={18} grow>
+                        {stats.map((s, i) => (
+                            <Box key={i} className={classes.statCard}>
+                                <Text className="af-mono" fz={18} fw={600} style={{ color: s.accent ? "var(--af-success)" : undefined }}>
+                                    {s.value}
+                                    {s.unit && <Text span className="af-mono" fz={11} c="var(--af-dim)">{s.unit}</Text>}
+                                </Text>
+                                <Text fz={11} c="var(--af-dim)" mt={3}>{s.label}</Text>
+                            </Box>
+                        ))}
+                    </Group>
+                )}
+            </Box>
+
+            {extra && <Box className={classes.extra}>{extra}</Box>}
+
+            {/* item list */}
+            <Box className={classes.list}>
+                {items.length === 0 ? (
+                    <Group justify="center" py="xl">
+                        <IconLoader2 size={22} className={classes.spin} color={accentVar} />
+                    </Group>
+                ) : (
+                    <Stack gap={11}>
+                        {items.map((it) => (
+                            <ItemRow key={it.key} item={it} accent={accentVar} />
+                        ))}
+                    </Stack>
+                )}
+            </Box>
+
+            {/* footer */}
+            <Group className={classes.footer} justify="space-between" wrap="nowrap">
+                {footer}
+            </Group>
+        </Modal>
+    );
+}
+
+/** Success / partial-failure banner used in the done/error states */
+export function ProgressBanner({
+    tone,
+    title,
+    detail,
+}: {
+    tone: "success" | "error";
+    title: string;
+    detail: string;
+}) {
+    const color = tone === "success" ? "var(--af-success)" : "var(--af-error)";
+    const Icon = tone === "success" ? IconCircleCheck : IconAlertTriangle;
+    return (
+        <Box
+            className={classes.banner}
+            style={{
+                background: `color-mix(in oklch, ${color} 9%, transparent)`,
+                border: `1px solid color-mix(in oklch, ${color} 30%, transparent)`,
+            }}
+        >
+            <span
+                className={classes.bannerIcon}
+                style={{ background: `color-mix(in oklch, ${color} 16%, transparent)`, color }}
+            >
+                <Icon size={22} stroke={2.2} />
+            </span>
+            <div>
+                <Text fz={14.5} fw={600} style={{ color }}>{title}</Text>
+                <Text className="af-mono" fz={11.5} c="var(--af-muted)" mt={3}>{detail}</Text>
+            </div>
+        </Box>
+    );
+}

--- a/src/components/ProgressModal/styles.module.css
+++ b/src/components/ProgressModal/styles.module.css
@@ -1,0 +1,114 @@
+.modalContent {
+    background: var(--af-surface);
+    border: 1px solid var(--af-border-strong);
+    overflow: hidden;
+}
+
+.header {
+    padding: 20px 22px;
+    border-bottom: 1px solid var(--af-border);
+}
+
+.section {
+    padding: 22px;
+    border-bottom: 1px solid var(--af-border);
+}
+
+.overallTrack {
+    height: 8px;
+    border-radius: 999px;
+    background: var(--af-bg);
+    overflow: hidden;
+}
+
+.overallFill {
+    height: 100%;
+    border-radius: 999px;
+    transition: width 250ms ease;
+}
+
+.statCard {
+    background: var(--af-bg);
+    border: 1px solid var(--af-border);
+    border-radius: var(--mantine-radius-sm);
+    padding: 12px;
+}
+
+.extra {
+    padding: 16px 22px;
+    border-bottom: 1px solid var(--af-border);
+}
+
+.logBox {
+    background: var(--af-bg);
+    border: 1px solid var(--af-border);
+    border-radius: var(--mantine-radius-sm);
+    padding: 10px 12px;
+    max-height: 130px;
+    overflow-y: auto;
+}
+
+.list {
+    padding: 16px 22px;
+    max-height: 280px;
+    overflow-y: auto;
+}
+
+.track {
+    flex: 1;
+    height: 5px;
+    border-radius: 3px;
+    background: var(--af-bg);
+    overflow: hidden;
+}
+
+.fill {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 250ms ease;
+}
+
+.waiting {
+    opacity: 0.5;
+}
+
+.errorRow {
+    background: color-mix(in oklch, var(--af-error) 7%, transparent);
+    border: 1px solid color-mix(in oklch, var(--af-error) 28%, transparent);
+    border-radius: 11px;
+    padding: 12px 13px;
+}
+
+.footer {
+    padding: 15px 22px;
+    border-top: 1px solid var(--af-border);
+    background: var(--af-bg);
+}
+
+.banner {
+    margin: 22px 22px 0;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    border-radius: var(--mantine-radius-md);
+    padding: 16px 18px;
+}
+
+.bannerIcon {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+}
+
+.spin {
+    animation: af-spin 0.9s linear infinite;
+}
+
+@keyframes af-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}

--- a/src/components/Upload/FileItem/index.tsx
+++ b/src/components/Upload/FileItem/index.tsx
@@ -18,7 +18,9 @@ export const FileItem = memo(function FileItemMemo ({
 }) {
     const showCheck = status === 'done' || status === 'published';
     const showProgress = ['processing', 'uploading', 'publishing'].includes(status);
+    const isError = status === 'error';
     const showIdle = !status || ['waiting'].includes(status);
+    const ringColor = isError ? 'npm' : 'success';
 
     return (
         <Card
@@ -31,12 +33,19 @@ export const FileItem = memo(function FileItemMemo ({
                 <RingProgress
                     sections={[
                         {
-                            value: percent,
-                            color: "green"
+                            value: isError ? 100 : percent,
+                            color: ringColor
                         }
                     ]}
                     label={
                         <Center>
+                            {isError && (
+                                <IconX
+                                    size="1.3em"
+                                    stroke={3}
+                                    color="var(--af-error)"
+                                />
+                            )}
                             {showCheck && (
                                 <IconCheck
                                     size="1.3em"
@@ -63,8 +72,8 @@ export const FileItem = memo(function FileItemMemo ({
                 <div
                     style={{flex: 1}}
                 >
-                    <Text size="sm">{file.name}</Text>
-                    <Text size="xs" c="dimmed">{(file.size / 1_000_000).toFixed(2)}MB</Text>
+                    <Text size="sm" ff="monospace" style={{ wordBreak: "break-all" }}>{file.name}</Text>
+                    <Text size="xs" c="dimmed" ff="monospace">{(file.size / 1_000_000).toFixed(2)}MB</Text>
                 </div>
                 <ActionIcon
                     variant="transparent"

--- a/src/components/Upload/Modal/index.tsx
+++ b/src/components/Upload/Modal/index.tsx
@@ -1,8 +1,8 @@
 import { Accordion, Button, Flex, Group, Modal, ScrollArea, Text } from "@mantine/core";
-import { IconStackFront } from "@tabler/icons-react";
 import { memo } from "react";
 import { ManifestItem } from "./ManifestItem";
 import { Layer } from "@/lib/progressBus";
+import { AccentTile } from "@/components/AccentTile";
 
 type UploadModalType = {
     jobId: string|null;
@@ -37,21 +37,16 @@ export const UploadModal = memo(function UploadModalMemo ({
             >
                 <Group
                     justify="space-between"
+                    wrap="nowrap"
                 >
-                    <Group
-                        gap="xs"
-                    >
-                        <IconStackFront />
-                        <Text
-                            fw="bold"
-                            size="lg"
-                        >
-                            アップロード進捗
-                        </Text>
+                    <Group gap="sm" wrap="nowrap">
+                        <AccentTile color="docker" code="DKR" size="lg" />
+                        <div>
+                            <Text fw={600} fz={15}>アップロード進捗</Text>
+                            <Text className="af-mono" fz={11} c="var(--af-dim)" mt={2}>Registry へ push</Text>
+                        </div>
                     </Group>
-                    <Text
-                        size="xs"
-                    >
+                    <Text className="af-mono" size="xs" c="var(--af-dim)">
                         {jobId}
                     </Text>
                 </Group>
@@ -75,13 +70,13 @@ export const UploadModal = memo(function UploadModalMemo ({
                     </Accordion>
                 </ScrollArea>
                 <Button
-                    color="dark"
+                    variant="default"
                     radius="md"
                     size="md"
                     fullWidth
                     onClick={onClose}
                 >
-                    とじる
+                    閉じる
                 </Button>
             </Flex>
         </Modal>

--- a/src/components/managers.tsx
+++ b/src/components/managers.tsx
@@ -1,0 +1,80 @@
+import {
+    IconBrandDocker,
+    IconBrandNpm,
+    IconBrandPython,
+    IconBox,
+    IconBrain,
+    type TablerIcon,
+} from "@tabler/icons-react";
+
+export type ManagerId = "docker" | "npm" | "pip" | "rpm" | "hf";
+
+export type Manager = {
+    id: ManagerId;
+    /** Mantine theme color key + CSS accent var suffix */
+    color: ManagerId;
+    label: string;
+    /** short code shown inside the accent tile */
+    code: string;
+    href: string;
+    Icon: TablerIcon;
+    blurb: string;
+    tags: string[];
+};
+
+export const MANAGERS: Manager[] = [
+    {
+        id: "docker",
+        color: "docker",
+        label: "Docker",
+        code: "DKR",
+        href: "/docker",
+        Icon: IconBrandDocker,
+        blurb: "イメージを依存ごと pull → docker load 可能な tar に。push も対応。",
+        tags: ["pull", "push"],
+    },
+    {
+        id: "npm",
+        color: "npm",
+        label: "npm",
+        code: "NPM",
+        href: "/npm",
+        Icon: IconBrandNpm,
+        blurb: "lockfile / name@semver から依存を全解決し全 tarball を取得。",
+        tags: ["lockfile", "publish"],
+    },
+    {
+        id: "pip",
+        color: "pip",
+        label: "pip",
+        code: "PIP",
+        href: "/pip",
+        Icon: IconBrandPython,
+        blurb: "PyPI / 社内インデックスから依存込みでまとめて取得・アップロード。",
+        tags: ["requirements", "upload"],
+    },
+    {
+        id: "rpm",
+        color: "rpm",
+        label: "rpm",
+        code: "RPM",
+        href: "/rpm",
+        Icon: IconBox,
+        blurb: "公式リポジトリ / EPEL から依存込みで収集。任意の RPM リポジトリへ。",
+        tags: ["deps", "EPEL"],
+    },
+    {
+        id: "hf",
+        color: "hf",
+        label: "Hugging Face",
+        code: "HF",
+        href: "/hf",
+        Icon: IconBrain,
+        blurb: "GGUF 等の必要ファイルだけ選択取得し、Ollama 等で使えるアーカイブに。",
+        tags: ["gguf", "select"],
+    },
+];
+
+export const MANAGERS_BY_ID: Record<ManagerId, Manager> = Object.fromEntries(
+    MANAGERS.map((m) => [m.id, m]),
+) as Record<ManagerId, Manager>;

--- a/src/lib/docker/registryPusher.ts
+++ b/src/lib/docker/registryPusher.ts
@@ -83,7 +83,10 @@ async function pushBlob(c: any, repo: string, tag: string, digest: string, file:
 
     const rawLocation = init.headers['location'];           // 例: /v2/...  or http://127.0.0.1:8081/v2/...
     const base = new URL(c.defaults.baseURL);               // 例: https://nexus/repository/docker-hub-clone
-    const wantPrefix = '/repository/docker-hub-clone';      // ← registry のパス部分を抽出しておく
+    // registry URL のパス部分を抽出する（例: /repository/docker-hub-clone）。
+    // Nexus が Location を /v2/... だけで返す場合に、この prefix を補って
+    // 正しいアップロード先 URL を組み立てる。リポジトリ名を固定しないこと。
+    const wantPrefix = base.pathname.replace(/\/+$/, '');
 
     let uploadUrl: string;
     if (/^https?:\/\//i.test(rawLocation)) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -74,5 +74,12 @@ export function middleware(req: NextRequest) {
 
 export const config = {
     // 静的アセットと Next.js 内部リクエストを除く全ルートを保護する。
-    matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+    //
+    // ただしアップロード系 API（multipart の大容量ボディ）は除外する。
+    // ミドルウェアを通過するリクエストは Next.js がボディを tee して
+    // experimental.middlewareClientMaxBodySize（既定 10MB）で打ち切るため、
+    // 大きな tar/パッケージが途中で切られ busboy が "Unexpected end of form" を
+    // 投げてしまう。これらのルートはミドルウェアを通さず元のボディを
+    // 直接ストリーミングさせる（メモリにバッファせず安全に大容量を扱える）。
+    matcher: ['/((?!_next/static|_next/image|favicon.ico|api/(?:docker|npm|pip|rpm)/upload).*)'],
 };

--- a/theme.ts
+++ b/theme.ts
@@ -1,5 +1,138 @@
 'use client';
 
-import { createTheme } from "@mantine/core";
+import { createTheme, type MantineColorsTuple } from "@mantine/core";
 
-export const theme = createTheme({});
+/**
+ * Carbon design system — Claude Design (ArtifactFetcher UI 刷新) より。
+ * ダークをデフォルトに、深い neutral 基調 + 成果物アクセント。
+ * アクセントは「一貫した L/C、hue のみ変化」の方針に従い oklch で生成する。
+ */
+function accentScale(baseL: number, c: number, h: number): MantineColorsTuple {
+    const ok = (l: number, cc: number) => `oklch(${l.toFixed(3)} ${cc.toFixed(3)} ${h})`;
+    return [
+        ok(0.96, c * 0.30),
+        ok(0.92, c * 0.50),
+        ok(0.86, c * 0.70),
+        ok(0.80, c * 0.85),
+        ok(0.74, c * 0.95),
+        ok(0.70, c),
+        ok(baseL, c),                 // 6 — base (filled)
+        ok(Math.max(baseL - 0.08, 0.2), c),
+        ok(Math.max(baseL - 0.16, 0.16), c),
+        ok(Math.max(baseL - 0.24, 0.12), c),
+    ] as unknown as MantineColorsTuple;
+}
+
+// 成果物アクセント（oklch）
+const docker = accentScale(0.66, 0.16, 250);
+const npm = accentScale(0.62, 0.20, 25);
+const pip = accentScale(0.64, 0.18, 300);
+const rpm = accentScale(0.82, 0.14, 90);
+const hf = accentScale(0.72, 0.13, 188);
+
+// ステータス
+const success = accentScale(0.74, 0.15, 150);
+const warning = accentScale(0.80, 0.14, 80);
+
+// Carbon neutrals（ダーク面）— dark[7]=body, dark[6]=surface, dark[0]=text
+const dark: MantineColorsTuple = [
+    '#F2F4F8', // 0 text
+    '#C0C6D0', // 1 strong muted
+    '#9AA1AE', // 2 muted (dimmed)
+    '#6B7280', // 3 dimmer / meta
+    '#3A3D44', // 4 strong border
+    '#24272F', // 5 border / hover
+    '#14161B', // 6 surface
+    '#0A0B0E', // 7 body bg
+    '#070809', // 8
+    '#050507', // 9
+];
+
+// 温かみのある light neutrals
+const gray: MantineColorsTuple = [
+    '#FBFAF8', // 0 bg
+    '#F2F0EC', // 1 raised
+    '#E8E6E2', // 2 border
+    '#D8D5CF', // 3
+    '#BAB6AE', // 4
+    '#9C9890', // 5
+    '#6A6E78', // 6 muted
+    '#4A4D55', // 7
+    '#2E3036', // 8
+    '#1B1C20', // 9 text
+];
+
+export const theme = createTheme({
+    primaryColor: 'docker',
+    primaryShade: 6,
+    autoContrast: true,
+    luminanceThreshold: 0.45,
+
+    fontFamily: "var(--font-plex-sans), system-ui, -apple-system, Segoe UI, sans-serif",
+    fontFamilyMonospace: "var(--font-plex-mono), ui-monospace, SFMono-Regular, Menlo, monospace",
+
+    defaultRadius: 'md',
+    radius: {
+        xs: '6px',
+        sm: '9px',
+        md: '14px',
+        lg: '18px',
+        xl: '24px',
+    },
+
+    white: '#FFFFFF',
+    black: '#0A0B0E',
+
+    colors: {
+        dark,
+        gray,
+        docker,
+        npm,
+        pip,
+        rpm,
+        hf,
+        success,
+        warning,
+    },
+
+    headings: {
+        fontWeight: '600',
+        sizes: {
+            h1: { fontSize: '2rem', lineHeight: '1.15', fontWeight: '600' },
+            h2: { fontSize: '1.5rem', lineHeight: '1.2', fontWeight: '600' },
+            h3: { fontSize: '1.25rem', lineHeight: '1.25', fontWeight: '600' },
+        },
+    },
+
+    components: {
+        Card: {
+            defaultProps: {
+                radius: 'lg',
+                withBorder: true,
+            },
+        },
+        Button: {
+            defaultProps: {
+                radius: 'md',
+            },
+        },
+        TextInput: {
+            defaultProps: { radius: 'md' },
+        },
+        PasswordInput: {
+            defaultProps: { radius: 'md' },
+        },
+        Modal: {
+            defaultProps: { radius: 'lg' },
+        },
+        Tabs: {
+            defaultProps: { radius: 'xl' },
+        },
+        Tooltip: {
+            defaultProps: { radius: 'sm', withArrow: true },
+        },
+        Badge: {
+            defaultProps: { radius: 'sm' },
+        },
+    },
+});


### PR DESCRIPTION
## What
Fixes the artifact upload flow, which failed end-to-end. Three independent defects:

1. **SSE progress 404** — the upload UI opened `/api/build/progress` before the POST created the `ProgressBus`, so the route 404'd. The route now lazily creates the bus when missing; `upload-multi` reuses it via `get(jobId)`.
2. **`Unexpected end of form` (500)** — feeding `req.body` to busboy via `Readable.fromWeb().pipe()` truncated the stream under Next 15.5/undici. All streaming upload routes (docker-multi/npm/pip/rpm) now pump the Web stream into busboy manually with backpressure and explicit `bb.end()`, switch the completion event to `close`, and guard per-file save promises against unhandled rejections on abort.
3. **10MB body cap** — requests through `middleware.ts` get their body teed and cut at `middlewareClientMaxBodySize` (10MB), corrupting large tars/packages. The upload API routes are excluded from the middleware matcher so they stream directly (raising the limit would buffer multi-GB images in memory).

Also derives the Nexus blob-upload `Location` prefix from the registry URL instead of hardcoding `/repository/docker-hub-clone`.

## Reviewer notes
- ⚠️ **Security**: excluding upload routes from middleware means they bypass app-wide Basic auth if `APP_AUTH_USER`/`APP_AUTH_PASSWORD` are ever enabled (currently unset). They still require registry credentials. Can add an in-handler auth check if needed.
- `middleware.ts` changes require a **server/container restart** (matcher is compiled into the build manifest).
- The `/v2 ping failed: 404` reported during testing was a config issue (registry URL was missing `/repository/`), not code — no change needed there beyond the prefix-derivation hardening.