### PR TITLE
npm/pip/rpm のダウンロードにプライベートリポジトリ用クレデンシャル入力を追加

### DIFF
--- a/src/app/api/npm/start/route.ts
+++ b/src/app/api/npm/start/route.ts
@@ -13,10 +13,15 @@ export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
 
 export async function POST(req: NextRequest) {
-    const { lockfile, specs, bundleName, registry } = await req.json();
+    const { lockfile, specs, bundleName, registry, username, password, token } = await req.json();
     if (!lockfile && !Array.isArray(specs)) {
         return new Response(JSON.stringify({ error: 'Provide lockfile text or specs[]' }), { status: 400 });
     }
+
+    // プライベートレジストリ用の認証情報（任意）。指定時のみ付与する。
+    const auth = (username || password || token)
+        ? { username: username || undefined, password: password || undefined, token: token || undefined }
+        : undefined;
 
     const detail = Array.isArray(specs)
         ? `npm:start specs=${specs.length}`
@@ -35,14 +40,14 @@ export async function POST(req: NextRequest) {
             jobStore.set(jobId, { status: 'running' });
             let lockText: string;
             if (Array.isArray(specs)) {
-                const { lockText: lt } = await makeLockFromSpecs(specs, bus, registry);
+                const { lockText: lt } = await makeLockFromSpecs(specs, bus, registry, auth);
                 lockText = lt;
             } else {
                 lockText = String(lockfile);
             }
             let workRoot: string | undefined;
             try {
-                const { tarPath, filename, workRoot: tmpRoot } = await buildTarFromLock({ lockText, bus, bundleName: bundleName || 'npm-offline' });
+                const { tarPath, filename, workRoot: tmpRoot } = await buildTarFromLock({ lockText, bus, bundleName: bundleName || 'npm-offline', registry, auth });
                 workRoot = tmpRoot;
                 const objectKey = `${jobId}/${filename}`;
                 bus.emitEvent({ type: 'stage', stage: 'uploading-s3' });

--- a/src/app/api/pip/start/route.ts
+++ b/src/app/api/pip/start/route.ts
@@ -11,6 +11,20 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
 
+// index URL に Basic 認証情報を埋め込む（pip は URL 内の userinfo を認証に使う）。
+// ユーザー名が無くトークンのみの場合は PyPI 慣習に倣い __token__ を使う。
+function injectCredentials(rawUrl: string, username?: string, password?: string): string {
+    if (!username && !password) return rawUrl;
+    try {
+        const u = new URL(rawUrl);
+        u.username = username || (password ? '__token__' : '');
+        u.password = password || '';
+        return u.toString();
+    } catch {
+        return rawUrl;
+    }
+}
+
 export async function POST(req: NextRequest) {
     const body = await req.json();
     const packages = Array.isArray(body.packages) ? (body.packages as string[]).map((s) => String(s).trim()).filter(Boolean) : undefined;
@@ -19,6 +33,8 @@ export async function POST(req: NextRequest) {
     const indexUrl = typeof body.indexUrl === 'string' && body.indexUrl.trim() ? body.indexUrl.trim() : undefined;
     const extraIndexUrls = Array.isArray(body.extraIndexUrls) ? body.extraIndexUrls.map((url: any) => String(url).trim()).filter(Boolean) : [];
     const trustedHosts = Array.isArray(body.trustedHosts) ? body.trustedHosts.map((h: any) => String(h).trim()).filter(Boolean) : [];
+    const username = typeof body.username === 'string' && body.username.trim() ? body.username.trim() : undefined;
+    const password = typeof body.password === 'string' && body.password ? body.password : undefined;
 
     if ((!packages || packages.length === 0) && !requirementsText) {
         return new Response(JSON.stringify({ error: 'packages[] or requirementsText is required' }), { status: 400 });
@@ -37,9 +53,9 @@ export async function POST(req: NextRequest) {
         try {
             jobStore.set(jobId, { status: 'running' });
             const pipArgs: string[] = [];
-            if (indexUrl) pipArgs.push('--index-url', indexUrl);
+            if (indexUrl) pipArgs.push('--index-url', injectCredentials(indexUrl, username, password));
             if (extraIndexUrls.length) {
-                for (const url of extraIndexUrls) pipArgs.push('--extra-index-url', url);
+                for (const url of extraIndexUrls) pipArgs.push('--extra-index-url', injectCredentials(url, username, password));
             }
             if (trustedHosts.length) {
                 for (const host of trustedHosts) pipArgs.push('--trusted-host', host);

--- a/src/app/api/rpm/start/route.ts
+++ b/src/app/api/rpm/start/route.ts
@@ -42,6 +42,10 @@ export async function POST(req: NextRequest) {
     const bundleName = typeof body.bundleName === 'string' && body.bundleName.trim() ? body.bundleName.trim() : 'rpm-offline';
     const repositoryIds = Array.isArray(body.repositories) ? body.repositories.map((s: any) => String(s).trim()).filter(Boolean) : [];
     const resolveDependencies = body.resolveDependencies !== false;
+    // プライベートリポジトリ用の認証情報（任意）。カスタムリポジトリにのみ付与する
+    // （プリセットは公開ミラーのため資格情報は不要）。
+    const username = typeof body.username === 'string' && body.username.trim() ? body.username.trim() : undefined;
+    const password = typeof body.password === 'string' && body.password ? body.password : undefined;
 
     if (!packages.length) {
         return new Response(JSON.stringify({ error: 'packages[] is required' }), { status: 400 });
@@ -50,7 +54,9 @@ export async function POST(req: NextRequest) {
     let repositories: RpmRepository[];
     try {
         const presetRepos = RPM_REPO_PRESETS.filter((repo) => repositoryIds.includes(repo.id));
-        const customRepos = normalizeCustomRepositories(body.customRepositories);
+        const customRepos = normalizeCustomRepositories(body.customRepositories).map((repo) => (
+            (username || password) ? { ...repo, username, password } : repo
+        ));
         const usedIds = new Set<string>();
         repositories = [...presetRepos, ...customRepos].map((repo) => {
             let nextId = repo.id;

--- a/src/app/npm/download.tsx
+++ b/src/app/npm/download.tsx
@@ -2,7 +2,7 @@
 
 import { LayerCard } from "@/components/LayerCard";
 import { LockEntry } from "@/lib/progressBus";
-import { Alert, Button, Group, Modal, Progress, Space, Stack, Text, ScrollArea, Center, Loader, Badge, Textarea } from "@mantine/core";
+import { Alert, Button, Group, Modal, Progress, Space, Stack, Text, ScrollArea, Center, Loader, Badge, Textarea, TextInput, PasswordInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
 import { IconCircleCheck, IconDownload, IconStackFront } from "@tabler/icons-react";
@@ -20,7 +20,10 @@ export function DownloadPane () {
     const esRef = useRef<EventSource | null>(null);
     const form = useForm({
         initialValues: {
-            packages: ""
+            packages: "",
+            registry: "",
+            username: "",
+            password: ""
         },
         validate: {
             packages: (v) => v=="" ? "パッケージ名を入力してください" : null
@@ -49,7 +52,10 @@ export function DownloadPane () {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     specs,
-                    bundleName: 'npm-from-specs'
+                    bundleName: 'npm-from-specs',
+                    registry: values.registry.trim() || undefined,
+                    username: values.username.trim() || undefined,
+                    password: values.password || undefined
                 }),
             });
             if (!res.ok) { alert("Failed to start"); return; }
@@ -133,6 +139,38 @@ export function DownloadPane () {
                         minRows={5}
                         autosize
                     />
+                    <TextInput
+                        label="レジストリ URL"
+                        description="プライベートレジストリを使う場合に指定（未指定なら npm 公式）"
+                        size="lg"
+                        radius="lg"
+                        placeholder="https://nexus.example.com/repository/npm-registry/"
+                        key={form.key("registry")}
+                        {...form.getInputProps("registry")}
+                        disabled={loading}
+                    />
+                    <Group grow align="flex-start">
+                        <TextInput
+                            label="ユーザー名"
+                            description="プライベートレジストリの認証用（任意）"
+                            size="lg"
+                            radius="lg"
+                            placeholder="username"
+                            key={form.key("username")}
+                            {...form.getInputProps("username")}
+                            disabled={loading}
+                        />
+                        <PasswordInput
+                            label="パスワード / トークン"
+                            description="ユーザー名なしの場合はトークンとして扱います"
+                            size="lg"
+                            radius="lg"
+                            placeholder="password / token"
+                            key={form.key("password")}
+                            {...form.getInputProps("password")}
+                            disabled={loading}
+                        />
+                    </Group>
                     <Space h="md" />
                     <Button
                         size="lg"

--- a/src/app/pip/download.tsx
+++ b/src/app/pip/download.tsx
@@ -2,7 +2,7 @@
 
 import { PipPackageCard } from '@/components/PipPackageCard';
 import { ProgressEvent, type PipPackage } from '@/lib/progressBus';
-import { Alert, Badge, Button, Center, Group, Loader, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Alert, Badge, Button, Center, Group, Loader, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput, PasswordInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { IconCircleCheck, IconDownload, IconStackFront } from '@tabler/icons-react';
@@ -23,6 +23,8 @@ type FormValues = {
     indexUrl: string;
     extraIndexUrls: string;
     trustedHosts: string;
+    username: string;
+    password: string;
 };
 
 function PipDownloadModal({ opened, onClose, jobId, status, packages, perPackage }: {
@@ -171,6 +173,8 @@ export function DownloadPane() {
             indexUrl: '',
             extraIndexUrls: '',
             trustedHosts: '',
+            username: '',
+            password: '',
         },
         validate: {
             packages: (value, values) => {
@@ -319,6 +323,8 @@ export function DownloadPane() {
             .map((s) => s.trim())
             .filter(Boolean);
         if (trustedHosts.length) payload.trustedHosts = trustedHosts;
+        if (values.username.trim()) payload.username = values.username.trim();
+        if (values.password) payload.password = values.password;
 
         try {
             const res = await fetch('/api/pip/start', {
@@ -409,6 +415,29 @@ export function DownloadPane() {
                             placeholder="https://pypi.org/simple"
                             key={form.key('indexUrl')}
                             {...form.getInputProps('indexUrl')}
+                            disabled={loading}
+                        />
+                    </Group>
+
+                    <Group grow align="flex-start">
+                        <TextInput
+                            label="ユーザー名 (任意)"
+                            description="プライベートな Index URL の認証用"
+                            size="lg"
+                            radius="lg"
+                            placeholder="username"
+                            key={form.key('username')}
+                            {...form.getInputProps('username')}
+                            disabled={loading}
+                        />
+                        <PasswordInput
+                            label="パスワード / トークン (任意)"
+                            description="ユーザー名なしの場合は __token__ として扱います"
+                            size="lg"
+                            radius="lg"
+                            placeholder="password / token"
+                            key={form.key('password')}
+                            {...form.getInputProps('password')}
                             disabled={loading}
                         />
                     </Group>

--- a/src/app/rpm/download.tsx
+++ b/src/app/rpm/download.tsx
@@ -2,7 +2,7 @@
 
 import { PipPackageCard } from '@/components/PipPackageCard';
 import { ProgressEvent, type RpmPackage } from '@/lib/progressBus';
-import { Alert, Button, Checkbox, Group, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput, Badge, Loader, Center } from '@mantine/core';
+import { Alert, Button, Checkbox, Group, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput, Badge, Loader, Center, PasswordInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { IconCircleCheck, IconDownload, IconStackFront } from '@tabler/icons-react';
@@ -71,6 +71,8 @@ export function DownloadPane() {
             repositories: repoOptions.map((o) => o.value),
             customRepositories: '',
             resolveDependencies: true,
+            username: '',
+            password: '',
         },
         validate: {
             packages: (v) => (v.trim() ? null : 'rpm package名を入力してください'),
@@ -128,6 +130,8 @@ export function DownloadPane() {
                     repositories: values.repositories,
                     customRepositories: customRepositoriesParsed.repositories,
                     resolveDependencies: values.resolveDependencies,
+                    username: values.username.trim() || undefined,
+                    password: values.password || undefined,
                 }),
             });
             if (!res.ok) throw new Error('start failed');
@@ -199,6 +203,28 @@ export function DownloadPane() {
                         {...form.getInputProps('customRepositories')}
                         disabled={loading}
                     />
+                    <Group grow align="flex-start">
+                        <TextInput
+                            label="ユーザー名 (任意)"
+                            description="プライベートなカスタムリポジトリの認証用"
+                            size="lg"
+                            radius="lg"
+                            placeholder="username"
+                            key={form.key('username')}
+                            {...form.getInputProps('username')}
+                            disabled={loading}
+                        />
+                        <PasswordInput
+                            label="パスワード / トークン (任意)"
+                            description="カスタムリポジトリにのみ適用されます"
+                            size="lg"
+                            radius="lg"
+                            placeholder="password / token"
+                            key={form.key('password')}
+                            {...form.getInputProps('password')}
+                            disabled={loading}
+                        />
+                    </Group>
                     <Checkbox label="依存関係もダウンロード (--resolve --alldeps)" key={form.key('resolveDependencies')} {...form.getInputProps('resolveDependencies', { type: 'checkbox' })} />
                     <Space h="md" />
                     <Button size="lg" radius="lg" type="submit" loading={loading}>Download</Button>

--- a/src/lib/npm/arboristLock.ts
+++ b/src/lib/npm/arboristLock.ts
@@ -5,7 +5,38 @@ import Arborist from '@npmcli/arborist';
 import npa from 'npm-package-arg';
 import { ProgressBus } from '../progressBus';
 
-export async function makeLockFromSpecs(specs: string[], bus: ProgressBus, registry?: string) {
+// プライベートレジストリ用の認証情報。upload 側と同じく
+// 「ユーザー名 + パスワード/トークン」で受け取る。
+export type NpmAuth = {
+    username?: string;
+    password?: string;
+    token?: string;
+};
+
+/**
+ * npm-registry-fetch の `forceAuth` 形式を組み立てる。
+ * forceAuth はレジストリのホストに依らず全リクエスト（packument / tarball）に
+ * 適用されるため、メタデータ解決とダウンロードの双方で認証が効く。
+ *
+ * - token あり → Bearer（_authToken）
+ * - username + secret → Basic（_auth = base64(user:pass)）
+ * - username なしで secret のみ → トークンとみなして Bearer
+ */
+export function buildNpmForceAuth(auth?: NpmAuth): Record<string, unknown> | undefined {
+    if (!auth) return undefined;
+    const token = auth.token?.trim();
+    const username = auth.username?.trim();
+    const secret = auth.password ?? '';
+    if (token) return { _authToken: token, alwaysAuth: true };
+    if (username) {
+        const basic = Buffer.from(`${username}:${secret}`).toString('base64');
+        return { _auth: basic, alwaysAuth: true };
+    }
+    if (secret) return { _authToken: secret, alwaysAuth: true };
+    return undefined;
+}
+
+export async function makeLockFromSpecs(specs: string[], bus: ProgressBus, registry?: string, auth?: NpmAuth) {
     bus.emitEvent({ type: 'stage', stage: 'arborist-init' });
     const work = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'npmlock-'));
     const pkgJson = {
@@ -17,8 +48,11 @@ export async function makeLockFromSpecs(specs: string[], bus: ProgressBus, regis
         ),
     };
     await fs.promises.writeFile(path.join(work, 'package.json'), JSON.stringify(pkgJson, null, 2));
-    
-    const arb = new Arborist({ path: work, registry: registry || undefined });
+
+    const arbOpts: Record<string, unknown> = { path: work, registry: registry || undefined };
+    const forceAuth = buildNpmForceAuth(auth);
+    if (forceAuth) arbOpts.forceAuth = forceAuth;
+    const arb = new Arborist(arbOpts as any);
     bus.emitEvent({ type: 'stage', stage: 'resolve-deps' });
     await arb.reify({ add: [], save: true });
     const lockText = await fs.promises.readFile(path.join(work, 'package-lock.json'), 'utf8');

--- a/src/lib/npm/downloader.ts
+++ b/src/lib/npm/downloader.ts
@@ -5,6 +5,27 @@ import path from 'node:path';
 import * as tar from 'tar';
 import { parseLockfile } from './lockParser';
 import { ProgressBus, type LockEntry } from '../progressBus';
+import type { NpmAuth } from './arboristLock';
+
+// tarball ダウンロード用の Authorization ヘッダを組み立てる。
+// username があれば Basic、なければトークン(secret)として Bearer。
+function buildNpmAuthHeader(auth?: NpmAuth): Record<string, string> {
+    if (!auth) return {};
+    const token = auth.token?.trim();
+    const username = auth.username?.trim();
+    const secret = auth.password ?? '';
+    if (username) {
+        return { Authorization: `Basic ${Buffer.from(`${username}:${secret}`).toString('base64')}` };
+    }
+    if (token) return { Authorization: `Bearer ${token}` };
+    if (secret) return { Authorization: `Bearer ${secret}` };
+    return {};
+}
+
+function sameHost(a: string, b: string): boolean {
+    try { return new URL(a).host === new URL(b).host; }
+    catch { return false; }
+}
 
 async function requestWithRetry(config: any, retries = 5, baseDelayMs = 500) {
     let attempt = 0;
@@ -24,17 +45,25 @@ async function requestWithRetry(config: any, retries = 5, baseDelayMs = 500) {
 export async function buildTarFromLock({
     lockText,
     bus,
-    bundleName = 'npm-offline'
+    bundleName = 'npm-offline',
+    registry,
+    auth,
 }: {
     lockText: string;
     bus: ProgressBus;
     bundleName?: string;
+    registry?: string;
+    auth?: NpmAuth;
 }) {
     bus.emitEvent({ type: 'stage', stage: 'parse-lockfile' });
     let entries: LockEntry[] = parseLockfile(lockText);
     entries = entries.filter(e => !!e.resolved);
     bus.emitEvent({ type: 'manifest-resolved', items: entries });
-    
+
+    // レジストリと同一ホストの tarball にのみ認証ヘッダを付与する。
+    // （public な tarball 配信元へ資格情報を漏らさないため）
+    const authHeader = buildNpmAuthHeader(auth);
+
     const workRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'npmdl-'));
     const dir = path.join(workRoot, bundleName);
     await fs.promises.mkdir(path.join(dir, 'npm', 'tarballs'), { recursive: true });
@@ -48,7 +77,8 @@ export async function buildTarFromLock({
         
         bus.emitEvent({ type: 'stage', stage: `download-${i}` });
         
-        const res = await requestWithRetry({ method: 'GET', url, responseType: 'stream' });
+        const headers = (registry && sameHost(url, registry)) ? authHeader : undefined;
+        const res = await requestWithRetry({ method: 'GET', url, responseType: 'stream', headers });
         const total = parseInt(res.headers['content-length'] || '0', 10);
         bus.emitEvent({ type: 'item-start', index: i, digest: `${e.name}@${e.version}`, total: total || undefined });
         

--- a/src/lib/rpm/downloader.ts
+++ b/src/lib/rpm/downloader.ts
@@ -17,6 +17,8 @@ export type RpmRepository = {
     label: string;
     folderName: string;
     baseUrl: string;
+    username?: string;
+    password?: string;
 };
 
 export const RPM_REPO_PRESETS: RpmRepoPreset[] = [
@@ -213,6 +215,9 @@ export async function buildRpmBundle({ specs, bundleName = 'rpm-offline', reposi
         args.push('--repofrompath', `${repo.id},${repo.baseUrl}`);
         args.push('--setopt', `${repo.id}.gpgcheck=0`);
         args.push('--setopt', `${repo.id}.repo_gpgcheck=0`);
+        // プライベートリポジトリの Basic 認証（dnf のリポジトリオプション）。
+        if (repo.username) args.push('--setopt', `${repo.id}.username=${repo.username}`);
+        if (repo.password) args.push('--setopt', `${repo.id}.password=${repo.password}`);
         args.push('--enablerepo', repo.id);
     }
 


### PR DESCRIPTION
## 概要
GitHub Release や社内 Nexus などにある docker image / npm パッケージ等の資材ダウンロードについて、**プライベートリポジトリで必要なログイン情報を入力できる**ようにしました。パブリックなら従来どおり空欄で取得できます。

upload 側と同じ「ユーザー名 + パスワード/トークン」入力を、認証欄が無かった **npm・pip・rpm** のダウンロード画面に追加します（docker・hf は対応済みのため対象外）。

## 変更内容
### npm
- 依存解決(arborist/pacote)に `forceAuth` を渡し、メタデータ取得を認証
- tarball 取得時に Authorization ヘッダを付与（**レジストリと同一ホストのみ**。公開 CDN へ資格情報を漏らさない）
- ユーザー名あり→Basic、シークレットのみ→Bearer トークン
- UI にレジストリ URL・ユーザー名・パスワード/トークン欄を追加

### pip
- `--index-url` / `--extra-index-url` に `user:pass@` を埋め込み
- トークンのみの場合は PyPI 慣習の `__token__` をユーザー名に使用
- UI にユーザー名・パスワード/トークン欄を追加

### rpm
- dnf の `--setopt <repo>.username/password` で Basic 認証を設定
- 認証情報は**カスタムリポジトリにのみ**適用（プリセットの CentOS/EPEL は公開ミラー）
- UI にユーザー名・パスワード/トークン欄を追加

## レビュー時の留意点
- **rpm のトークン認証**: dnf は Basic 認証ベースのため、Nexus のトークン利用時は「ユーザー名 + トークン(=パスワード)」で入力する必要があります（トークンのみは不可）。npm/pip はトークンのみでも可。
- **資格情報の露出**: pip は creds を `--index-url` 経由で子プロセスへ渡すため、サーバの `ps` で見えます（社内ツール想定で許容）。SSE ログ上は pip がパスワードをマスクします。
- 型チェック(`tsc`) と lint(`eslint`) はパス済み。実 Nexus での疎通は未検証です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)