### PR TITLE
ダウンロードフォームのマージ起因のビルド失敗を修正 (npm/pip/rpm)

### DIFF
--- a/src/app/npm/download.tsx
+++ b/src/app/npm/download.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { LockEntry } from "@/lib/progressBus";
-import { Alert, Button, Group, Modal, Progress, Space, Stack, Text, ScrollArea, Center, Loader, Badge, Textarea, TextInput, PasswordInput } from "@mantine/core";
+import { Button, Text, Group, TextInput, PasswordInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
 import { IconAlertCircle, IconDownload } from "@tabler/icons-react";
@@ -173,17 +173,13 @@ export function DownloadPane () {
                             disabled={loading}
                         />
                     </Group>
-                    <Space h="md" />
-                    <Button
-                        size="lg"
-                        radius="lg"
-                        type="submit"
-                        loading={loading}
-                    >
-                        Download
-                    </Button>
-                </Stack>
-            </form>
+                </CarbonSection>
+
+                <CarbonFooter hint="依存を解決して tar 化します">
+                    {jobId && status !== "idle" && <CarbonGhostButton onClick={open}>進捗を表示</CarbonGhostButton>}
+                    <CarbonSubmit loading={loading}>取得を開始</CarbonSubmit>
+                </CarbonFooter>
+            </CarbonForm>
 
             {error && (
                 <div className={carbonClasses.errorText} style={{ marginTop: 16 }}>

--- a/src/app/pip/download.tsx
+++ b/src/app/pip/download.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ProgressEvent, type PipPackage } from '@/lib/progressBus';
-import { Alert, Badge, Button, Center, Group, Loader, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput, PasswordInput } from '@mantine/core';
+import { Button, Group, Text, TextInput, PasswordInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { IconAlertCircle, IconBox, IconDownload, IconWorld } from '@tabler/icons-react';
@@ -349,29 +349,17 @@ export function DownloadPane() {
                         disabled={loading}
                         desc="複数指定する場合は改行またはカンマ区切り"
                     />
-                    <Group grow>
-                        <TextInput
-                            label="バンドル名"
-                            description="出力tarファイル名のベースになります"
-                            size="lg"
-                            radius="lg"
-                            placeholder="pip-offline"
-                            key={form.key('bundleName')}
-                            {...form.getInputProps('bundleName')}
-                            disabled={loading}
-                        />
-                        <TextInput
-                            label="Index URL (任意)"
-                            description="社内PyPIなどを利用する場合に指定"
-                            size="lg"
-                            radius="lg"
-                            placeholder="https://pypi.org/simple"
-                            key={form.key('indexUrl')}
-                            {...form.getInputProps('indexUrl')}
-                            disabled={loading}
-                        />
-                    </Group>
-
+                    <CarbonTextarea
+                        label="Trusted Hosts"
+                        optional
+                        small
+                        value={form.getValues().trustedHosts}
+                        onChange={(val) => form.setFieldValue('trustedHosts', val)}
+                        placeholder="nexus.example.com"
+                        rows={2}
+                        disabled={loading}
+                        desc="自己署名証明書で TLS 検証をスキップする場合に指定"
+                    />
                     <Group grow align="flex-start">
                         <TextInput
                             label="ユーザー名 (任意)"
@@ -394,20 +382,6 @@ export function DownloadPane() {
                             disabled={loading}
                         />
                     </Group>
-
-                    <Textarea
-                        label="Extra Index URLs (任意)"
-                        description="複数指定する場合は改行またはカンマ区切りで入力"
-                        size="lg"
-                        radius="lg"
-                        placeholder={`https://internal.example.com/simple\nhttps://another.example.com/simple`}
-                        key={form.key('extraIndexUrls')}
-                        {...form.getInputProps('extraIndexUrls')}
-                        minRows={3}
-                        autosize
-                        disabled={loading}
-                        desc="自己署名証明書で TLS 検証をスキップする場合に指定"
-                    />
                 </CarbonAuthPanel>
 
                 <CarbonSection label="取得対象">

--- a/src/app/rpm/download.tsx
+++ b/src/app/rpm/download.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ProgressEvent, type RpmPackage } from '@/lib/progressBus';
-import { Alert, Button, Checkbox, Group, Modal, Progress, ScrollArea, Space, Stack, Text, Textarea, TextInput, Badge, Loader, Center, PasswordInput } from '@mantine/core';
+import { Button, ScrollArea, Stack, Text, TextInput, PasswordInput, Group } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { IconAlertCircle, IconBox, IconDownload } from '@tabler/icons-react';
@@ -222,44 +222,35 @@ export function DownloadPane() {
                         desc="rpm 名をスペースまたは改行区切りで入力"
                         error={form.errors.packages as string | undefined}
                     />
-                    <Group grow align="flex-start">
-                        <TextInput
-                            label="ユーザー名 (任意)"
-                            description="プライベートなカスタムリポジトリの認証用"
-                            size="lg"
-                            radius="lg"
-                            placeholder="username"
-                            key={form.key('username')}
-                            {...form.getInputProps('username')}
-                            disabled={loading}
-                        />
-                        <PasswordInput
-                            label="パスワード / トークン (任意)"
-                            description="カスタムリポジトリにのみ適用されます"
-                            size="lg"
-                            radius="lg"
-                            placeholder="password / token"
-                            key={form.key('password')}
-                            {...form.getInputProps('password')}
-                            disabled={loading}
-                        />
-                    </Group>
-                    <Checkbox label="依存関係もダウンロード (--resolve --alldeps)" key={form.key('resolveDependencies')} {...form.getInputProps('resolveDependencies', { type: 'checkbox' })} />
-                    <Space h="md" />
-                    <Button size="lg" radius="lg" type="submit" loading={loading}>Download</Button>
-                </Stack>
-            </form>
-            {error && <Alert color="red" radius="lg" title="エラー" my="lg" variant="light">{error}</Alert>}
+                    <CarbonField
+                        label="Bundle name"
+                        optional
+                        icon={IconBox}
+                        value={fv.bundleName}
+                        onChange={(val) => form.setFieldValue('bundleName', val)}
+                        placeholder="rpm-offline"
+                        disabled={loading}
+                    />
+                    <CarbonCheckbox
+                        checked={fv.resolveDependencies}
+                        onChange={(c) => form.setFieldValue('resolveDependencies', c)}
+                        label="依存関係もダウンロード (--resolve --alldeps)"
+                        disabled={loading}
+                    />
+                </CarbonSection>
 
-            <Modal opened={opened} onClose={handleCloseModal} centered radius="lg" size="lg" transitionProps={{ transition: 'pop' }} withCloseButton>
-                <Group justify="space-between"><Group gap="xs"><IconStackFront /><Text fw="bold" size="lg">ダウンロード進捗</Text></Group>{status === 'done' ? <Badge color="green" leftSection={<IconCircleCheck size="1em" />} radius="sm">done</Badge> : <Badge color={status === 'error' ? 'red' : 'gray'} leftSection={status === 'error' ? undefined : <Loader size="1em" color="white" />} radius="sm">{status}</Badge>}</Group>
-                {jobId && <Text size="xs" c="dimmed">jobId: {jobId}</Text>}
-                <Stack gap={10} py="xs"><Group justify="space-between"><Text fw="bold">全体の進捗</Text><Text>{overallPercent}%</Text></Group><Progress value={overallPercent} size="lg" radius="xl" /><Text size="xs" c="dimmed">{(totals.received / 1_000_000).toFixed(2)}MB / {(totals.total / 1_000_000).toFixed(2)}MB</Text></Stack>
-                <Stack gap={8}>
-                    <Text size="sm" fw={600}>現在のステージ: {currentStage}</Text>
-                    <ScrollArea h={150} type="auto" offsetScrollbars>
-                        <Stack gap={2}>
-                            {logs.length === 0 ? <Text size="xs" c="dimmed">ログ待機中...</Text> : logs.map((line, idx) => <Text key={`${line}-${idx}`} size="xs" ff="monospace">{line}</Text>)}
+                <div style={{ borderTop: '1px solid var(--af-border)' }}>
+                    <CarbonSection label="リポジトリ">
+                        <Stack gap={10}>
+                            {repoOptions.map((repo) => (
+                                <CarbonCheckbox
+                                    key={repo.value}
+                                    checked={fv.repositories.includes(repo.value)}
+                                    onChange={() => toggleRepo(repo.value)}
+                                    label={repo.label}
+                                    disabled={loading}
+                                />
+                            ))}
                         </Stack>
                         <CarbonTextarea
                             label="Custom repositories"
@@ -273,6 +264,28 @@ export function DownloadPane() {
                             desc="1行1件。URL のみ、または id|label|url 形式で入力"
                             error={form.errors.customRepositories as string | undefined}
                         />
+                        <Group grow align="flex-start">
+                            <TextInput
+                                label="ユーザー名 (任意)"
+                                description="プライベートなカスタムリポジトリの認証用"
+                                size="lg"
+                                radius="lg"
+                                placeholder="username"
+                                key={form.key('username')}
+                                {...form.getInputProps('username')}
+                                disabled={loading}
+                            />
+                            <PasswordInput
+                                label="パスワード / トークン (任意)"
+                                description="カスタムリポジトリにのみ適用されます"
+                                size="lg"
+                                radius="lg"
+                                placeholder="password / token"
+                                key={form.key('password')}
+                                {...form.getInputProps('password')}
+                                disabled={loading}
+                            />
+                        </Group>
                     </CarbonSection>
                 </div>
 


### PR DESCRIPTION
## 概要
Carbon リデザインとダウンロード用クレデンシャル追加のマージで、npm/pip/rpm の `download.tsx` の JSX が壊れ、`next build` が失敗していた問題を修正します。

## 原因と修正
- **npm / rpm**: CarbonSection/CarbonFooter 構造になるべき箇所に、旧 Mantine の `</Stack></form>` と送信ボタンが残存（`TS17002: Expected corresponding JSX closing tag`）。
- **pip**: 旧 Mantine の重複フィールド（バンドル名/Index URL の `Group`、および Carbon 専用 prop `desc` を渡した `Textarea`）が残り型エラー（`TS2322`）。リデザインの Trusted Hosts 欄が欠落。

各フォームを Carbon レイアウトへ再構成しつつ、追加済みのクレデンシャル入力（ユーザー名 + パスワード/トークン）を保持。未使用となった Mantine import も整理しました。

## 検証
- `tsc --noEmit`: パス
- `eslint`(対象3ファイル): エラー・警告なし
- `next build`: 成功（全11ページ生成。/npm・/pip・/rpm 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)