### PR TITLE
npm スコープ別レジストリ認証 + クレデンシャル入力の Carbon 化

### DIFF
--- a/src/app/npm/download.tsx
+++ b/src/app/npm/download.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { LockEntry } from "@/lib/progressBus";
-import { Button, Text, Group, TextInput, PasswordInput } from "@mantine/core";
+import { Button, Text } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
-import { IconAlertCircle, IconDownload } from "@tabler/icons-react";
+import { IconAlertCircle, IconDownload, IconWorld, IconUser, IconKey } from "@tabler/icons-react";
 import { useCallback, useRef, useState } from "react";
 import { ProgressEvent } from "@/lib/progressBus";
 import { ProgressBanner, ProgressModal, type ProgressItem } from "@/components/ProgressModal";
-import { CarbonForm, CarbonSection, CarbonTextarea, CarbonFooter, CarbonSubmit, CarbonGhostButton, carbonClasses } from "@/components/CarbonForm";
+import { CarbonForm, CarbonSection, CarbonTextarea, CarbonAuthPanel, CarbonField, CarbonPassword, CarbonFooter, CarbonSubmit, CarbonGhostButton, carbonClasses } from "@/components/CarbonForm";
 
 export function DownloadPane () {
     const [loading, setLoading] = useState(false);
@@ -130,49 +130,57 @@ export function DownloadPane () {
     return (
         <div>
             <CarbonForm accent="npm" onSubmit={form.onSubmit(onSubmit)}>
+                <CarbonAuthPanel
+                    icon={IconWorld}
+                    title="レジストリ / 認証"
+                    sub={`${form.getValues().registry?.trim() || 'registry.npmjs.org'} · ${form.getValues().username || form.getValues().password ? '認証あり' : '認証なし'}`}
+                    configured={Boolean(form.getValues().registry?.trim() || form.getValues().username || form.getValues().password)}
+                    defaultOpen={false}
+                >
+                    <CarbonField
+                        label="レジストリ URL"
+                        optional
+                        small
+                        icon={IconWorld}
+                        value={form.getValues().registry}
+                        onChange={(v) => form.setFieldValue("registry", v)}
+                        placeholder="https://npm.pkg.github.com"
+                        disabled={loading}
+                        desc="プライベートレジストリを使う場合に指定（未指定なら npm 公式）"
+                    />
+                    <CarbonField
+                        label="ユーザー名"
+                        optional
+                        small
+                        icon={IconUser}
+                        value={form.getValues().username}
+                        onChange={(v) => form.setFieldValue("username", v)}
+                        placeholder="username"
+                        disabled={loading}
+                        desc="未指定の場合はパスワード欄をトークンとして扱います"
+                    />
+                    <CarbonPassword
+                        label="パスワード / トークン"
+                        optional
+                        icon={IconKey}
+                        value={form.getValues().password}
+                        onChange={(v) => form.setFieldValue("password", v)}
+                        placeholder="password / token"
+                        disabled={loading}
+                    />
+                </CarbonAuthPanel>
+
                 <CarbonSection label="取得対象">
                     <CarbonTextarea
                         label={<>パッケージ名 <span className={carbonClasses.required}>必須</span></>}
                         value={form.getValues().packages}
                         onChange={(v) => form.setFieldValue("packages", v)}
-                        placeholder="react@^18 axios"
+                        placeholder="@gariton/callisto-client react@^18"
                         rows={5}
                         disabled={loading}
                         desc="ダウンロードしたいパッケージ名をスペースまたは改行で区切って入力"
                         error={form.errors.packages as string | undefined}
                     />
-                    <TextInput
-                        label="レジストリ URL"
-                        description="プライベートレジストリを使う場合に指定（未指定なら npm 公式）"
-                        size="lg"
-                        radius="lg"
-                        placeholder="https://nexus.example.com/repository/npm-registry/"
-                        key={form.key("registry")}
-                        {...form.getInputProps("registry")}
-                        disabled={loading}
-                    />
-                    <Group grow align="flex-start">
-                        <TextInput
-                            label="ユーザー名"
-                            description="プライベートレジストリの認証用（任意）"
-                            size="lg"
-                            radius="lg"
-                            placeholder="username"
-                            key={form.key("username")}
-                            {...form.getInputProps("username")}
-                            disabled={loading}
-                        />
-                        <PasswordInput
-                            label="パスワード / トークン"
-                            description="ユーザー名なしの場合はトークンとして扱います"
-                            size="lg"
-                            radius="lg"
-                            placeholder="password / token"
-                            key={form.key("password")}
-                            {...form.getInputProps("password")}
-                            disabled={loading}
-                        />
-                    </Group>
                 </CarbonSection>
 
                 <CarbonFooter hint="依存を解決して tar 化します">

--- a/src/app/pip/download.tsx
+++ b/src/app/pip/download.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { ProgressEvent, type PipPackage } from '@/lib/progressBus';
-import { Button, Group, Text, TextInput, PasswordInput } from '@mantine/core';
+import { Button, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconAlertCircle, IconBox, IconDownload, IconWorld } from '@tabler/icons-react';
+import { IconAlertCircle, IconBox, IconDownload, IconWorld, IconUser, IconKey } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
-import { CarbonForm, CarbonSection, CarbonField, CarbonTextarea, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonGhostButton, carbonClasses } from '@/components/CarbonForm';
+import { CarbonForm, CarbonSection, CarbonField, CarbonTextarea, CarbonAuthPanel, CarbonFooter, CarbonSubmit, CarbonGhostButton, CarbonPassword, carbonClasses } from '@/components/CarbonForm';
 
 type Status = 'idle' | 'starting' | 'running' | 'done' | 'error';
 
@@ -360,28 +360,26 @@ export function DownloadPane() {
                         disabled={loading}
                         desc="自己署名証明書で TLS 検証をスキップする場合に指定"
                     />
-                    <Group grow align="flex-start">
-                        <TextInput
-                            label="ユーザー名 (任意)"
-                            description="プライベートな Index URL の認証用"
-                            size="lg"
-                            radius="lg"
-                            placeholder="username"
-                            key={form.key('username')}
-                            {...form.getInputProps('username')}
-                            disabled={loading}
-                        />
-                        <PasswordInput
-                            label="パスワード / トークン (任意)"
-                            description="ユーザー名なしの場合は __token__ として扱います"
-                            size="lg"
-                            radius="lg"
-                            placeholder="password / token"
-                            key={form.key('password')}
-                            {...form.getInputProps('password')}
-                            disabled={loading}
-                        />
-                    </Group>
+                    <CarbonField
+                        label="ユーザー名"
+                        optional
+                        small
+                        icon={IconUser}
+                        value={form.getValues().username}
+                        onChange={(val) => form.setFieldValue('username', val)}
+                        placeholder="username"
+                        disabled={loading}
+                        desc="プライベートな Index URL の認証用"
+                    />
+                    <CarbonPassword
+                        label="パスワード / トークン"
+                        optional
+                        icon={IconKey}
+                        value={form.getValues().password}
+                        onChange={(val) => form.setFieldValue('password', val)}
+                        placeholder="password / token"
+                        disabled={loading}
+                    />
                 </CarbonAuthPanel>
 
                 <CarbonSection label="取得対象">

--- a/src/app/rpm/download.tsx
+++ b/src/app/rpm/download.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { ProgressEvent, type RpmPackage } from '@/lib/progressBus';
-import { Button, ScrollArea, Stack, Text, TextInput, PasswordInput, Group } from '@mantine/core';
+import { Button, ScrollArea, Stack, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { IconAlertCircle, IconBox, IconDownload } from '@tabler/icons-react';
+import { IconAlertCircle, IconBox, IconDownload, IconUser, IconKey } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ProgressBanner, ProgressModal, type ProgressItem } from '@/components/ProgressModal';
-import { CarbonForm, CarbonSection, CarbonField, CarbonTextarea, CarbonCheckbox, CarbonFooter, CarbonSubmit, carbonClasses } from '@/components/CarbonForm';
+import { CarbonForm, CarbonSection, CarbonField, CarbonTextarea, CarbonCheckbox, CarbonPassword, CarbonFooter, CarbonSubmit, carbonClasses } from '@/components/CarbonForm';
 
 const repoOptions = [
     { value: 'centos-stream-9-baseos', label: 'CentOS Stream 9 BaseOS (official)' },
@@ -264,28 +264,26 @@ export function DownloadPane() {
                             desc="1行1件。URL のみ、または id|label|url 形式で入力"
                             error={form.errors.customRepositories as string | undefined}
                         />
-                        <Group grow align="flex-start">
-                            <TextInput
-                                label="ユーザー名 (任意)"
-                                description="プライベートなカスタムリポジトリの認証用"
-                                size="lg"
-                                radius="lg"
-                                placeholder="username"
-                                key={form.key('username')}
-                                {...form.getInputProps('username')}
-                                disabled={loading}
-                            />
-                            <PasswordInput
-                                label="パスワード / トークン (任意)"
-                                description="カスタムリポジトリにのみ適用されます"
-                                size="lg"
-                                radius="lg"
-                                placeholder="password / token"
-                                key={form.key('password')}
-                                {...form.getInputProps('password')}
-                                disabled={loading}
-                            />
-                        </Group>
+                        <CarbonField
+                            label="ユーザー名"
+                            optional
+                            small
+                            icon={IconUser}
+                            value={fv.username}
+                            onChange={(val) => form.setFieldValue('username', val)}
+                            placeholder="username"
+                            disabled={loading}
+                            desc="プライベートなカスタムリポジトリの認証用"
+                        />
+                        <CarbonPassword
+                            label="パスワード / トークン"
+                            optional
+                            icon={IconKey}
+                            value={fv.password}
+                            onChange={(val) => form.setFieldValue('password', val)}
+                            placeholder="password / token"
+                            disabled={loading}
+                        />
                     </CarbonSection>
                 </div>
 

--- a/src/lib/npm/arboristLock.ts
+++ b/src/lib/npm/arboristLock.ts
@@ -14,26 +14,38 @@ export type NpmAuth = {
 };
 
 /**
- * npm-registry-fetch の `forceAuth` 形式を組み立てる。
- * forceAuth はレジストリのホストに依らず全リクエスト（packument / tarball）に
- * 適用されるため、メタデータ解決とダウンロードの双方で認証が効く。
- *
- * - token あり → Bearer（_authToken）
- * - username + secret → Basic（_auth = base64(user:pass)）
- * - username なしで secret のみ → トークンとみなして Bearer
+ * registry URL を npm の nerf-dart 形式（`//host/path/`）に正規化する。
+ * npm-registry-fetch はこのキー（`//host/path/:_authToken` など）で認証情報を引く。
  */
-export function buildNpmForceAuth(auth?: NpmAuth): Record<string, unknown> | undefined {
-    if (!auth) return undefined;
+export function nerfDart(registry: string): string {
+    const withSlash = registry.endsWith('/') ? registry : `${registry}/`;
+    const u = new URL(withSlash);
+    return `//${u.host}${u.pathname}`;
+}
+
+/**
+ * 指定レジストリのホストに対してのみ有効な認証設定（nerf-dart スコープ）を作る。
+ * forceAuth と異なり、そのホスト以外（public npm 等）には認証情報を送らないため、
+ * プライベートスコープ + public 依存の混在を安全に解決できる。
+ *
+ * - username + secret → Basic（username / _password[base64]）
+ * - username なしで token/secret のみ → Bearer（_authToken）
+ */
+export function buildNpmRegistryAuth(registry: string, auth?: NpmAuth): Record<string, string> {
+    if (!auth) return {};
+    const nd = nerfDart(registry);
     const token = auth.token?.trim();
     const username = auth.username?.trim();
     const secret = auth.password ?? '';
-    if (token) return { _authToken: token, alwaysAuth: true };
     if (username) {
-        const basic = Buffer.from(`${username}:${secret}`).toString('base64');
-        return { _auth: basic, alwaysAuth: true };
+        return {
+            [`${nd}:username`]: username,
+            [`${nd}:_password`]: Buffer.from(secret).toString('base64'),
+        };
     }
-    if (secret) return { _authToken: secret, alwaysAuth: true };
-    return undefined;
+    if (token) return { [`${nd}:_authToken`]: token };
+    if (secret) return { [`${nd}:_authToken`]: secret };
+    return {};
 }
 
 export async function makeLockFromSpecs(specs: string[], bus: ProgressBus, registry?: string, auth?: NpmAuth) {
@@ -49,9 +61,25 @@ export async function makeLockFromSpecs(specs: string[], bus: ProgressBus, regis
     };
     await fs.promises.writeFile(path.join(work, 'package.json'), JSON.stringify(pkgJson, null, 2));
 
-    const arbOpts: Record<string, unknown> = { path: work, registry: registry || undefined };
-    const forceAuth = buildNpmForceAuth(auth);
-    if (forceAuth) arbOpts.forceAuth = forceAuth;
+    const arbOpts: Record<string, unknown> = { path: work };
+    if (registry) {
+        // 指定パッケージのうちスコープ付き（@scope/...）のスコープを抽出する。
+        const scopes = Array.from(new Set(
+            specs.map((s) => { try { return npa(s).scope; } catch { return undefined; } })
+                .filter((s): s is string => !!s)
+        ));
+        if (scopes.length) {
+            // スコープ単位でレジストリを割り当てる。
+            // → @scope は指定レジストリから、その他（public 依存）は既定の npm から解決。
+            for (const scope of scopes) arbOpts[`${scope}:registry`] = registry;
+        } else {
+            // スコープ無し → 既定レジストリ自体を差し替える（プライベートミラー想定）。
+            arbOpts.registry = registry;
+        }
+        // 認証は指定レジストリのホストにのみ送る（public npm にトークンを漏らさない）。
+        Object.assign(arbOpts, buildNpmRegistryAuth(registry, auth));
+    }
+
     const arb = new Arborist(arbOpts as any);
     bus.emitEvent({ type: 'stage', stage: 'resolve-deps' });
     await arb.reify({ add: [], save: true });


### PR DESCRIPTION
## 概要
1. **GitHub Packages 等のプライベートスコープ + public npm 依存** を含む npm パッケージをダウンロードできるようにしました（例: `@gariton/callisto-client`）。
2. 先に追加したダウンロードページのクレデンシャル入力欄が Mantine 素のデザインだったのを、**Carbon コンポーネント**に置き換えました。

## 1. npm スコープ別レジストリ
- 指定パッケージにスコープ（`@scope/...`）がある場合、そのスコープだけを `@scope:registry` で指定レジストリへ振り分け、**既定レジストリは public npm のまま**にします。これにより推移的な public 依存は npmjs から解決されます。
- 認証は `forceAuth`（全ホストに送信）をやめ、**nerf-dart 形式のホスト別キー**（`//host/path/:_authToken` または `:username`+`:_password`）で付与。トークンは**プライベートレジストリのホストにのみ**送られ、`registry.npmjs.org` には漏れません。
- スコープ無しの指定時は従来どおり既定レジストリを差し替え（プライベートミラー想定）。

### `@gariton/callisto-client` の設定例
| 項目 | 値 |
|---|---|
| レジストリ URL | `https://npm.pkg.github.com` |
| ユーザー名 | （空欄） |
| パスワード / トークン | GitHub PAT（`read:packages`） |
| パッケージ名 | `@gariton/callisto-client` |

## 2. クレデンシャル入力の Carbon 化
- npm: 認証欄を `CarbonAuthPanel` + `CarbonField` / `CarbonPassword` に変更
- pip / rpm: `CarbonField` / `CarbonPassword` に変更
- 未使用になった Mantine import（TextInput/PasswordInput/Group 等）を整理

## 検証
- `@gariton/callisto-client@1.0.0` を GitHub Packages から、依存（socket.io-client / debug / engine.io-client ほか）を public npm から解決できることを arborist で実機確認（計12パッケージ）。GitHub から解決された tarball のみトークンが付与される。
- `tsc --noEmit` / `eslint`(対象ファイル) / `next build` すべてパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)